### PR TITLE
fix(mac): add audio-input entitlement for microphone access

### DIFF
--- a/assets/entitlements.mac.plist
+++ b/assets/entitlements.mac.plist
@@ -12,5 +12,7 @@
     <true/>
     <key>com.apple.security.device.camera</key>
     <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
   </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Adds missing `com.apple.security.device.audio-input` entitlement to Mac builds
- Fixes silent audio failure in production builds with hardened runtime

## Root Cause
The custom `entitlements.mac.plist` had USB and camera permissions but was missing the audio-input entitlement. macOS silently blocks `getUserMedia()` audio requests without this permission when hardened runtime is enabled.

## Test plan
- [ ] Build Mac app with `npm run build`
- [ ] Verify audio works in the packaged/signed app