### PR TITLE
fix(ui): preserve stream border in fullscreen mode

### DIFF
--- a/src/app/renderer/assets/styles/layout.css
+++ b/src/app/renderer/assets/styles/layout.css
@@ -104,17 +104,6 @@ body.fullscreen-active .stream-section {
   gap: 0;
 }
 
-/* Fullscreen: Minimal border, remove outer glow/shadow */
-body.fullscreen-active .stream-container {
-  border: none;
-  box-shadow: none;
-  background: #000;
-}
-
-/* Hide rainbow border in fullscreen for cleaner look */
-body.fullscreen-active .stream-container::before {
-  display: none;
-}
 
 /* Header */
 .header {


### PR DESCRIPTION
## Description

Corrected issue where viewport border was not visible in fullscreen mode.

## Testing

- [x] `npm run lint` passes
- [x] `npm run test:run` passes
- [x] Manually tested (if applicable)

## Checklist

- [x] Code follows project style
- [x] Commits use [conventional commits](https://www.conventionalcommits.org/) format
- [x] Documentation updated (if needed)
