### PR TITLE
fix(ci): migrate from macos-13 to macos-15-intel runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,11 +113,11 @@ jobs:
           PLATFORMS="${{ inputs.platforms || 'all' }}"
 
           if [ "$PLATFORMS" == "all" ]; then
-            echo 'matrix=[{"os":"ubuntu-latest","build_script":"build:linux"},{"os":"macos-13","build_script":"build:mac","arch":"x64"},{"os":"macos-14","build_script":"build:mac","arch":"arm64"},{"os":"windows-latest","build_script":"build:win"}]' >> $GITHUB_OUTPUT
+            echo 'matrix=[{"os":"ubuntu-latest","build_script":"build:linux"},{"os":"macos-15-intel","build_script":"build:mac","arch":"x64"},{"os":"macos-14","build_script":"build:mac","arch":"arm64"},{"os":"windows-latest","build_script":"build:win"}]' >> $GITHUB_OUTPUT
           elif [ "$PLATFORMS" == "linux" ]; then
             echo 'matrix=[{"os":"ubuntu-latest","build_script":"build:linux"}]' >> $GITHUB_OUTPUT
           elif [ "$PLATFORMS" == "macos" ]; then
-            echo 'matrix=[{"os":"macos-13","build_script":"build:mac","arch":"x64"},{"os":"macos-14","build_script":"build:mac","arch":"arm64"}]' >> $GITHUB_OUTPUT
+            echo 'matrix=[{"os":"macos-15-intel","build_script":"build:mac","arch":"x64"},{"os":"macos-14","build_script":"build:mac","arch":"arm64"}]' >> $GITHUB_OUTPUT
           elif [ "$PLATFORMS" == "windows" ]; then
             echo 'matrix=[{"os":"windows-latest","build_script":"build:win"}]' >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
macOS 13 runner is being deprecated (GitHub actions/runner-images#13046). Migrate to macos-15-intel for Intel x64 Mac builds as recommended.

## Description

<!-- What does this PR do? -->

## Related Issues

<!-- Fixes #123 or Relates to #123 -->

## Testing

- [ ] `npm run lint` passes
- [ ] `npm run test:run` passes
- [ ] Manually tested (if applicable)

## Checklist

- [ ] Code follows project style
- [ ] Commits use [conventional commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated (if needed)
