### PR TITLE
feat: add minimalist fullscreen setting and behavior

### DIFF
--- a/src/renderer/assets/styles/states.css
+++ b/src/renderer/assets/styles/states.css
@@ -88,6 +88,74 @@ body.cinematic-active .stream-container::before {
 }
 
 /* =====================================================
+   Minimalist Fullscreen Mode
+   Pure black fullscreen with minimal controls (streaming only)
+   ===================================================== */
+
+body.minimalist-transition {
+  transition: background 250ms ease;
+}
+
+body.minimalist-transition::before,
+body.minimalist-transition::after,
+body.minimalist-transition .prismatic-orbs,
+body.minimalist-transition .prismatic-orbs::before,
+body.minimalist-transition .prismatic-orbs::after,
+body.minimalist-transition .stream-container,
+body.minimalist-transition .stream-container::before,
+body.minimalist-transition .fullscreen-controls,
+body.minimalist-transition .fs-control-btn {
+  transition: opacity 250ms ease, background 250ms ease, box-shadow 250ms ease, border-color 250ms ease, filter 250ms ease, transform 250ms ease;
+}
+
+body.fullscreen-active.streaming-mode.minimalist-fullscreen {
+  background: #000;
+}
+
+body.fullscreen-active.streaming-mode.minimalist-fullscreen::before,
+body.fullscreen-active.streaming-mode.minimalist-fullscreen::after {
+  opacity: 0;
+  animation: none;
+  filter: none;
+}
+
+body.fullscreen-active.streaming-mode.minimalist-fullscreen .prismatic-orbs,
+body.fullscreen-active.streaming-mode.minimalist-fullscreen .prismatic-orbs::before,
+body.fullscreen-active.streaming-mode.minimalist-fullscreen .prismatic-orbs::after {
+  opacity: 0;
+  animation: none;
+  filter: none;
+}
+
+body.fullscreen-active.streaming-mode.minimalist-fullscreen .stream-container {
+  box-shadow: none;
+}
+
+body.fullscreen-active.streaming-mode.minimalist-fullscreen .stream-container::before {
+  opacity: 0;
+}
+
+body.fullscreen-active.streaming-mode.minimalist-fullscreen .fullscreen-controls {
+  background: rgba(0, 0, 0, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.7);
+  backdrop-filter: none;
+}
+
+body.fullscreen-active.streaming-mode.minimalist-fullscreen .fs-control-btn {
+  color: #e6e6e6;
+}
+
+body.fullscreen-active.streaming-mode.minimalist-fullscreen .fs-control-btn:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: #ffffff;
+}
+
+body.fullscreen-active.streaming-mode.minimalist-fullscreen .fs-control-btn:focus-visible {
+  outline-color: rgba(255, 255, 255, 0.5);
+}
+
+/* =====================================================
    Cursor Auto-Hide
    Hide cursor after inactivity during streaming
    ===================================================== */
@@ -344,4 +412,3 @@ body.streaming-mode.cinematic-active .app-logo {
     opacity: 0.1;
   }
 }
-

--- a/src/renderer/features/settings/services/settings-preferences.orchestrator.js
+++ b/src/renderer/features/settings/services/settings-preferences.orchestrator.js
@@ -38,6 +38,7 @@ export class SettingsPreferencesOrchestrator extends BaseOrchestrator {
       // Apply volume via event (ShaderSelector listens for this)
       this.eventBus.publish(EventChannels.SETTINGS.VOLUME_CHANGED, preferences.volume);
       this.eventBus.publish(EventChannels.SETTINGS.PERFORMANCE_MODE_CHANGED, preferences.performanceMode);
+      this.eventBus.publish(EventChannels.SETTINGS.MINIMALIST_FULLSCREEN_CHANGED, preferences.minimalistFullscreen);
 
       // Status strip visibility is applied by SettingsMenuComponent on initialize
 

--- a/src/renderer/features/settings/services/settings.service.js
+++ b/src/renderer/features/settings/services/settings.service.js
@@ -25,7 +25,8 @@ class SettingsService extends BaseService {
       renderPreset: 'vibrant',
       globalBrightness: 1.0,
       performanceMode: false,
-      fullscreenOnStartup: false
+      fullscreenOnStartup: false,
+      minimalistFullscreen: false
     };
 
     // Use centralized storage keys
@@ -40,13 +41,17 @@ class SettingsService extends BaseService {
     const volume = this.getVolume();
     const statusStripVisible = this.getStatusStripVisible();
     const performanceMode = this.getPerformanceMode();
+    const minimalistFullscreen = this.getMinimalistFullscreen();
 
-    this.logger.info(`Loaded preferences - Volume: ${volume}%, StatusStrip: ${statusStripVisible}, PerformanceMode: ${performanceMode}`);
+    this.logger.info(
+      `Loaded preferences - Volume: ${volume}%, StatusStrip: ${statusStripVisible}, PerformanceMode: ${performanceMode}, MinimalistFullscreen: ${minimalistFullscreen}`
+    );
 
     return {
       volume,
       statusStripVisible,
-      performanceMode
+      performanceMode,
+      minimalistFullscreen
     };
   }
 
@@ -180,6 +185,28 @@ class SettingsService extends BaseService {
 
     // Emit event
     this.eventBus.publish(EventChannels.SETTINGS.FULLSCREEN_ON_STARTUP_CHANGED, enabled);
+  }
+
+  /**
+   * Get minimalist fullscreen preference
+   * @returns {boolean} True if minimalist fullscreen is enabled
+   */
+  getMinimalistFullscreen() {
+    const saved = this.storageService?.getItem(this.keys.MINIMALIST_FULLSCREEN);
+    return saved !== null ? saved === 'true' : this.defaults.minimalistFullscreen;
+  }
+
+  /**
+   * Set minimalist fullscreen preference
+   * @param {boolean} enabled - Enable minimalist fullscreen
+   */
+  setMinimalistFullscreen(enabled) {
+    this.storageService?.setItem(this.keys.MINIMALIST_FULLSCREEN, enabled.toString());
+
+    this.logger.debug(`Minimalist fullscreen ${enabled ? 'enabled' : 'disabled'}`);
+
+    // Emit event
+    this.eventBus.publish(EventChannels.SETTINGS.MINIMALIST_FULLSCREEN_CHANGED, enabled);
   }
 }
 

--- a/src/renderer/features/settings/ui/settings-menu.component.js
+++ b/src/renderer/features/settings/ui/settings-menu.component.js
@@ -34,6 +34,7 @@ class SettingsMenuComponent {
     this.toggleButton = elements.settingsBtn;
     this.statusStripCheckbox = elements.settingStatusStrip;
     this.fullscreenOnStartupCheckbox = elements.settingFullscreenOnStartup;
+    this.minimalistFullscreenCheckbox = elements.settingMinimalistFullscreen;
     this.animationSaverCheckbox = elements.settingAnimationSaver;
     this.disclaimerBtn = elements.disclaimerBtn;
     this.disclaimerContent = elements.disclaimerContent;
@@ -97,6 +98,14 @@ class SettingsMenuComponent {
       });
     }
 
+    // Minimalist fullscreen toggle
+    if (this.minimalistFullscreenCheckbox) {
+      this._domListeners.add(this.minimalistFullscreenCheckbox, 'change', () => {
+        const enabled = this.minimalistFullscreenCheckbox.checked;
+        this.settingsService.setMinimalistFullscreen(enabled);
+      });
+    }
+
     // Animation power saver toggle
     if (this.animationSaverCheckbox) {
       this._domListeners.add(this.animationSaverCheckbox, 'change', () => {
@@ -123,6 +132,7 @@ class SettingsMenuComponent {
   _loadCurrentSettings() {
     const statusStripVisible = this.settingsService.getStatusStripVisible();
     const fullscreenOnStartupEnabled = this.settingsService.getFullscreenOnStartup?.() ?? false;
+    const minimalistFullscreenEnabled = this.settingsService.getMinimalistFullscreen?.() ?? false;
     const performanceModeEnabled = this.settingsService.getPerformanceMode?.() ?? false;
 
     if (this.statusStripCheckbox) {
@@ -131,6 +141,10 @@ class SettingsMenuComponent {
 
     if (this.fullscreenOnStartupCheckbox) {
       this.fullscreenOnStartupCheckbox.checked = fullscreenOnStartupEnabled;
+    }
+
+    if (this.minimalistFullscreenCheckbox) {
+      this.minimalistFullscreenCheckbox.checked = minimalistFullscreenEnabled;
     }
 
     if (this.animationSaverCheckbox) {

--- a/src/renderer/infrastructure/events/event-channels.config.js
+++ b/src/renderer/infrastructure/events/event-channels.config.js
@@ -47,6 +47,7 @@ export const EventChannels = {
     PERFORMANCE_MODE_CHANGED: 'settings:performance-mode-changed',
     CINEMATIC_MODE_CHANGED: 'settings:cinematic-mode-changed',
     FULLSCREEN_ON_STARTUP_CHANGED: 'settings:fullscreen-on-startup-changed',
+    MINIMALIST_FULLSCREEN_CHANGED: 'settings:minimalist-fullscreen-changed',
     PREFERENCES_LOADED: 'settings:preferences-loaded',
     PREFERENCES_LOAD_FAILED: 'settings:preferences-load-failed'
   },

--- a/src/renderer/ui/controller/ui.controller.js
+++ b/src/renderer/ui/controller/ui.controller.js
@@ -73,6 +73,7 @@ class UIController {
       settingsMenuContainer: document.getElementById(DOMSelectors.SETTINGS_MENU_CONTAINER),
       settingStatusStrip: document.getElementById(DOMSelectors.SETTING_STATUS_STRIP),
       settingFullscreenOnStartup: document.getElementById(DOMSelectors.SETTING_FULLSCREEN_ON_STARTUP),
+      settingMinimalistFullscreen: document.getElementById(DOMSelectors.SETTING_MINIMALIST_FULLSCREEN),
       settingAnimationSaver: document.getElementById(DOMSelectors.SETTING_ANIMATION_SAVER),
       settingRenderPreset: document.getElementById(DOMSelectors.SETTING_RENDER_PRESET),
       disclaimerBtn: document.getElementById(DOMSelectors.DISCLAIMER_BTN),
@@ -312,6 +313,14 @@ class UIController {
    */
   updateCinematicMode(isActive) {
     this.effects?.setCinematicMode(isActive);
+  }
+
+  /**
+   * Update minimalist fullscreen visual state
+   * @param {boolean} isActive - Whether minimalist fullscreen should be visually active
+   */
+  updateMinimalistFullscreen(isActive) {
+    this.effects?.setMinimalistFullscreen(isActive);
   }
 
   /**

--- a/src/renderer/ui/effects/ui-effects.class.js
+++ b/src/renderer/ui/effects/ui-effects.class.js
@@ -34,6 +34,9 @@ export class UIEffects {
     this._controlsElement = null;
     this._lastMouseMoveTime = 0;
     this._mouseMoveThrottle = 100; // Throttle mousemove events to once per 100ms
+
+    // Minimalist transition state
+    this._minimalistTransitionTimer = null;
   }
 
   /**
@@ -366,6 +369,35 @@ export class UIEffects {
   }
 
   /**
+   * Set minimalist fullscreen body class
+   * @param {boolean} isActive - Whether minimalist fullscreen should be active
+   */
+  setMinimalistFullscreen(isActive) {
+    const currentlyActive = document.body.classList.contains(CSSClasses.MINIMALIST_FULLSCREEN);
+    if (currentlyActive === isActive) return;
+
+    this._setMinimalistTransitionActive();
+    document.body.classList.toggle(CSSClasses.MINIMALIST_FULLSCREEN, isActive);
+  }
+
+  /**
+   * Apply transition class for minimalist mode changes
+   * @private
+   */
+  _setMinimalistTransitionActive() {
+    if (this._minimalistTransitionTimer) {
+      clearTimeout(this._minimalistTransitionTimer);
+      this._minimalistTransitionTimer = null;
+    }
+
+    document.body.classList.add(CSSClasses.MINIMALIST_TRANSITION);
+    this._minimalistTransitionTimer = setTimeout(() => {
+      document.body.classList.remove(CSSClasses.MINIMALIST_TRANSITION);
+      this._minimalistTransitionTimer = null;
+    }, TIMING.MINIMALIST_TRANSITION_MS);
+  }
+
+  /**
    * Set fullscreen mode body class
    * @param {boolean} isActive - Whether fullscreen mode is active
    */
@@ -392,6 +424,12 @@ export class UIEffects {
       clearTimeout(timeoutId);
     }
     this._activeTimeouts.clear();
+
+    if (this._minimalistTransitionTimer) {
+      clearTimeout(this._minimalistTransitionTimer);
+      this._minimalistTransitionTimer = null;
+    }
+    document.body.classList.remove(CSSClasses.MINIMALIST_TRANSITION);
 
     // Clear element references
     this.elements = null;

--- a/src/renderer/ui/templates/header.template.js
+++ b/src/renderer/ui/templates/header.template.js
@@ -48,6 +48,16 @@ export default function createHeaderTemplate() {
                 </label>
                 <label class="settings-item toggle settings-item-with-hint">
                   <span class="settings-item-text">
+                    <span class="settings-item-title">Minimalist fullscreen</span>
+                    <span class="settings-item-hint" id="minimalistFullscreenHint">
+                      Pure black fullscreen with minimal controls during streaming.
+                    </span>
+                  </span>
+                  <input type="checkbox" id="settingMinimalistFullscreen" aria-describedby="minimalistFullscreenHint">
+                  <span class="toggle-slider"></span>
+                </label>
+                <label class="settings-item toggle settings-item-with-hint">
+                  <span class="settings-item-text">
                     <span class="settings-item-title">Performance mode</span>
                     <span class="settings-item-hint" id="animationSaverHint">
                       Pause background effects to improve performance.

--- a/src/shared/config/constants.config.js
+++ b/src/shared/config/constants.config.js
@@ -18,4 +18,7 @@ export const TIMING = {
 
   // Cursor auto-hide delay (ms)
   CURSOR_HIDE_DELAY_MS: 2000,
+
+  // Minimalist fullscreen transition duration (ms)
+  MINIMALIST_TRANSITION_MS: 250,
 };

--- a/src/shared/config/css-classes.config.js
+++ b/src/shared/config/css-classes.config.js
@@ -29,6 +29,8 @@ export const CSSClasses = {
 
   // Mode classes
   CINEMATIC_ACTIVE: 'cinematic-active',
+  MINIMALIST_FULLSCREEN: 'minimalist-fullscreen',
+  MINIMALIST_TRANSITION: 'minimalist-transition',
   STREAMING_MODE: 'streaming-mode',
 
   // Settings menu

--- a/src/shared/config/dom-selectors.config.js
+++ b/src/shared/config/dom-selectors.config.js
@@ -48,6 +48,7 @@ export const DOMSelectors = {
   SETTING_ANIMATION_SAVER: 'settingAnimationSaver',
   SETTING_RENDER_PRESET: 'settingRenderPreset',
   SETTING_FULLSCREEN_ON_STARTUP: 'settingFullscreenOnStartup',
+  SETTING_MINIMALIST_FULLSCREEN: 'settingMinimalistFullscreen',
   DISCLAIMER_BTN: 'disclaimerBtn',
   DISCLAIMER_CONTENT: 'disclaimerContent',
 

--- a/src/shared/config/storage-keys.config.js
+++ b/src/shared/config/storage-keys.config.js
@@ -14,7 +14,8 @@ export const SettingsStorageKeys = {
   RENDER_PRESET: 'renderPreset',
   GLOBAL_BRIGHTNESS: 'globalBrightness',
   PERFORMANCE_MODE: 'performanceMode',
-  FULLSCREEN_ON_STARTUP: 'fullscreenOnStartup'
+  FULLSCREEN_ON_STARTUP: 'fullscreenOnStartup',
+  MINIMALIST_FULLSCREEN: 'minimalistFullscreen'
 };
 
 /**
@@ -50,5 +51,6 @@ export const PROTECTED_STORAGE_KEYS = [
   SettingsStorageKeys.RENDER_PRESET,
   SettingsStorageKeys.GLOBAL_BRIGHTNESS,
   SettingsStorageKeys.PERFORMANCE_MODE,
-  SettingsStorageKeys.FULLSCREEN_ON_STARTUP
+  SettingsStorageKeys.FULLSCREEN_ON_STARTUP,
+  SettingsStorageKeys.MINIMALIST_FULLSCREEN
 ];

--- a/tests/unit/features/settings/services/settings.service.test.js
+++ b/tests/unit/features/settings/services/settings.service.test.js
@@ -57,6 +57,7 @@ describe('SettingsService', () => {
       expect(service.defaults.statusStripVisible).toBe(false);
       expect(service.defaults.performanceMode).toBe(false);
       expect(service.defaults.fullscreenOnStartup).toBe(false);
+      expect(service.defaults.minimalistFullscreen).toBe(false);
     });
 
     it('should have correct setting keys', () => {
@@ -66,6 +67,7 @@ describe('SettingsService', () => {
       expect(service.keys.GLOBAL_BRIGHTNESS).toBe('globalBrightness');
       expect(service.keys.PERFORMANCE_MODE).toBe('performanceMode');
       expect(service.keys.FULLSCREEN_ON_STARTUP).toBe('fullscreenOnStartup');
+      expect(service.keys.MINIMALIST_FULLSCREEN).toBe('minimalistFullscreen');
     });
   });
 
@@ -151,7 +153,8 @@ describe('SettingsService', () => {
       expect(prefs).toEqual({
         volume: 70,
         statusStripVisible: false,
-        performanceMode: false
+        performanceMode: false,
+        minimalistFullscreen: false
       });
     });
 
@@ -159,18 +162,20 @@ describe('SettingsService', () => {
       localStorageMock.store['gameVolume'] = '30';
       localStorageMock.store['statusStripVisible'] = 'false';
       localStorageMock.store['performanceMode'] = 'false';
+      localStorageMock.store['minimalistFullscreen'] = 'true';
 
       const prefs = service.loadAllPreferences();
       expect(prefs).toEqual({
         volume: 30,
         statusStripVisible: false,
-        performanceMode: false
+        performanceMode: false,
+        minimalistFullscreen: true
       });
     });
 
     it('should log loaded preferences', () => {
       service.loadAllPreferences();
-      expect(mockLogger.info).toHaveBeenCalledWith('Loaded preferences - Volume: 70%, StatusStrip: false, PerformanceMode: false');
+      expect(mockLogger.info).toHaveBeenCalledWith('Loaded preferences - Volume: 70%, StatusStrip: false, PerformanceMode: false, MinimalistFullscreen: false');
     });
   });
 

--- a/tests/unit/ui/ui-event-bridge.test.js
+++ b/tests/unit/ui/ui-event-bridge.test.js
@@ -45,6 +45,7 @@ describe('UIEventBridge', () => {
       updateFullscreenMode: vi.fn(),
       updateRecordingButtonState: vi.fn(),
       updateCinematicMode: vi.fn(),
+      updateMinimalistFullscreen: vi.fn(),
       elements: {
         recordBtn: {
           classList: {
@@ -129,6 +130,7 @@ describe('UIEventBridge', () => {
         'ui:button-feedback',
         'ui:recording-state',
         'settings:cinematic-mode-changed',
+        'settings:minimalist-fullscreen-changed',
         'ui:fullscreen-state'
       ];
 


### PR DESCRIPTION
## Summary
- Adds a new "Minimalist Fullscreen" setting option
- When enabled, hides header and controls UI elements in fullscreen mode for a cleaner viewing experience
- Includes CSS transitions for smooth fade in/out behavior

## Test plan
- [ ] Verify minimalist fullscreen toggle appears in settings menu
- [ ] Enable setting and enter fullscreen - header and controls should hide
- [ ] Move mouse - UI elements should fade back in
- [ ] Disable setting and verify UI remains visible in fullscreen
- [ ] Test persistence of setting across app restarts