### PR TITLE
feat: add toolbar auto-hide after inactivity

### DIFF
--- a/src/renderer/assets/styles/toolbar.css
+++ b/src/renderer/assets/styles/toolbar.css
@@ -24,13 +24,11 @@
   z-index: var(--z-tooltip);
 }
 
-/* Fade toolbar when mouse inactive */
-.stream-toolbar.faded {
-  opacity: 0.25;
-}
-
-.stream-toolbar:hover {
-  opacity: 1 !important;
+/* Hide toolbar when mouse inactive - needs high specificity to override cinematic mode */
+.stream-toolbar.toolbar-hidden,
+body.cinematic-active .stream-toolbar.toolbar-hidden {
+  opacity: 0;
+  pointer-events: none;
 }
 
 /* =====================================================

--- a/src/renderer/features/streaming/ui/streaming-shader-selector.component.js
+++ b/src/renderer/features/streaming/ui/streaming-shader-selector.component.js
@@ -2,7 +2,6 @@
  * Shader Selector Component
  *
  * Panel component for selecting shader presets and toggling cinematic mode.
- * Includes fullscreen mouse activity tracking for toolbar opacity.
  */
 
 import { createDomListenerManager } from '@shared/base/dom-listener.utils.js';
@@ -27,14 +26,12 @@ class StreamingShaderSelectorComponent {
 
     // Toolbar elements
     this.cinematicToggle = null;
-    this.toolbar = null;
     this.brightnessSlider = null;
     this.brightnessPercentage = null;
     this.brightnessControl = null;
     this.volumeSlider = null;
     this.volumePercentage = null;
     this.streamVideo = null;
-    this._mouseActivityTimeout = null;
 
     // Track DOM listeners for cleanup
     this._domListeners = createDomListenerManager({ logger });
@@ -49,7 +46,6 @@ class StreamingShaderSelectorComponent {
     this.button = elements.shaderBtn;
     this.dropdown = elements.shaderDropdown;
     this.cinematicToggle = elements.cinematicToggle;
-    this.toolbar = elements.streamToolbar;
     this.brightnessSlider = elements.brightnessSlider;
     this.brightnessPercentage = elements.brightnessPercentage;
     this.brightnessControl = this.brightnessSlider?.closest('.brightness-control');
@@ -72,7 +68,6 @@ class StreamingShaderSelectorComponent {
     this._setupCinematicToggle();
     this._setupBrightnessSlider();
     this._setupVolumeSlider();
-    this._setupFullscreenMouseActivity();
     this._subscribeToEvents();
 
     this.logger?.debug('StreamingShaderSelectorComponent initialized');
@@ -544,64 +539,9 @@ class StreamingShaderSelectorComponent {
   }
 
   /**
-   * Setup mouse activity tracking for toolbar fade
-   * Toolbar fades after 10 seconds of mouse inactivity
-   * @private
-   */
-  _setupFullscreenMouseActivity() {
-    if (!this.toolbar) return;
-
-    // Show toolbar on any mouse movement
-    this._domListeners.add(document, 'mousemove', () => {
-      this._showToolbar();
-      this._resetMouseActivityTimeout();
-    });
-
-    // Also show on mouse click
-    this._domListeners.add(document, 'mousedown', () => {
-      this._showToolbar();
-      this._resetMouseActivityTimeout();
-    });
-
-    // Start the initial fade timeout
-    this._resetMouseActivityTimeout();
-
-    this.logger?.debug('Mouse activity tracking initialized');
-  }
-
-  /**
-   * Show toolbar (remove faded class)
-   * @private
-   */
-  _showToolbar() {
-    this.toolbar?.classList.remove(CSSClasses.FADED);
-  }
-
-  /**
-   * Reset mouse activity timeout
-   * @private
-   */
-  _resetMouseActivityTimeout() {
-    if (this._mouseActivityTimeout) {
-      clearTimeout(this._mouseActivityTimeout);
-    }
-
-    this._mouseActivityTimeout = setTimeout(() => {
-      // Don't fade if panel is open
-      if (!this.isVisible) {
-        this.toolbar?.classList.add(CSSClasses.FADED);
-      }
-    }, 10000); // 10 seconds
-  }
-
-  /**
    * Dispose and cleanup event listeners
    */
   dispose() {
-    if (this._mouseActivityTimeout) {
-      clearTimeout(this._mouseActivityTimeout);
-      this._mouseActivityTimeout = null;
-    }
     this._domListeners.removeAll();
     this._eventSubscriptions.forEach(unsubscribe => unsubscribe());
     this._eventSubscriptions = [];

--- a/src/renderer/ui/controller/ui.controller.js
+++ b/src/renderer/ui/controller/ui.controller.js
@@ -224,9 +224,11 @@ class UIController {
   setStreamingMode(isStreaming) {
     this.registry?.get('streamControlsComponent')?.setStreamingMode(isStreaming);
     if (isStreaming) {
+      this.effects?.enableToolbarAutoHide(this.elements.streamToolbar);
       this.effects?.enableCursorAutoHide();
     } else {
       this.effects?.disableCursorAutoHide();
+      this.effects?.disableToolbarAutoHide();
       this.registry?.get('shaderSelectorComponent')?.hide?.();
     }
   }

--- a/src/shared/config/css-classes.config.js
+++ b/src/shared/config/css-classes.config.js
@@ -59,7 +59,9 @@ export const CSSClasses = {
   // Shader selector states
   PANEL_OPEN: 'panel-open',
   JUST_SELECTED: 'just-selected',
-  FADED: 'faded',
+
+  // Toolbar auto-hide
+  TOOLBAR_HIDDEN: 'toolbar-hidden',
 
   // Notes panel states
   LIST_COLLAPSED: 'list-collapsed',

--- a/tests/unit/ui/ui.controller.test.js
+++ b/tests/unit/ui/ui.controller.test.js
@@ -91,6 +91,8 @@ describe('UIController', () => {
       triggerButtonFeedback: vi.fn(),
       enableCursorAutoHide: vi.fn(),
       disableCursorAutoHide: vi.fn(),
+      enableToolbarAutoHide: vi.fn(),
+      disableToolbarAutoHide: vi.fn(),
       dispose: vi.fn()
     };
 
@@ -229,10 +231,24 @@ describe('UIController', () => {
       expect(mockEffects.enableCursorAutoHide).toHaveBeenCalled();
     });
 
+    it('should enable toolbar auto-hide when streaming starts', () => {
+      controller.setStreamingMode(true);
+
+      expect(mockEffects.enableToolbarAutoHide).toHaveBeenCalledWith(
+        controller.elements.streamToolbar
+      );
+    });
+
     it('should disable cursor auto-hide when streaming stops', () => {
       controller.setStreamingMode(false);
 
       expect(mockEffects.disableCursorAutoHide).toHaveBeenCalled();
+    });
+
+    it('should disable toolbar auto-hide when streaming stops', () => {
+      controller.setStreamingMode(false);
+
+      expect(mockEffects.disableToolbarAutoHide).toHaveBeenCalled();
     });
 
     it('should hide shader selector when disabling streaming', () => {


### PR DESCRIPTION
## Summary
- Streaming toolbar (shader, snapshot, recording, notes buttons) now auto-hides after 2 seconds of inactivity
- Uses the same delay as cursor auto-hide for consistency (`TIMING.CURSOR_HIDE_DELAY_MS`)
- Works in both windowed and fullscreen modes
- Toolbar stays visible when hovering or when panels (shader/notes) are open

## Implementation
- Added self-contained `enableToolbarAutoHide()`/`disableToolbarAutoHide()` methods to UIEffects
- Follows same pattern as `enableControlsAutoHide()` - has its own document mousemove listener
- Removed duplicate fade logic from shader selector component
- Added CSS with proper specificity to handle cinematic mode

## Test plan
- [x] All 2150 unit tests pass
- [x] Manually tested streaming on/off: toolbar appears/hides correctly
- [x] Manually tested idle timeout: toolbar hides after 2 seconds
- [x] Manually tested hover pause: toolbar stays visible while hovering
- [x] Manually tested panel open: toolbar stays visible when shader/notes panels are open
- [x] Manually tested fullscreen and windowed modes