### PR TITLE
feat: add fullscreen state synchronization

### DIFF
--- a/src/main/features/window/ipc/window-ipc.handler.js
+++ b/src/main/features/window/ipc/window-ipc.handler.js
@@ -18,4 +18,8 @@ export function registerWindowHandlers({ registerHandler, windowService, logger 
     windowService.setFullScreen(enabled);
     return { success: true };
   });
+
+  registerHandler(IPC_CHANNELS.WINDOW.IS_FULLSCREEN, async () => {
+    return windowService.isFullScreen();
+  });
 }

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -221,6 +221,8 @@ const windowAPI = {
 
   setFullScreen: (enabled) => ipcRenderer.invoke(IPC_CHANNELS.WINDOW.SET_FULLSCREEN, enabled),
 
+  isFullScreen: () => ipcRenderer.invoke(IPC_CHANNELS.WINDOW.IS_FULLSCREEN),
+
   removeListeners: () => {
     ipcRenderer.removeAllListeners(IPC_CHANNELS.WINDOW.ENTER_FULLSCREEN);
     ipcRenderer.removeAllListeners(IPC_CHANNELS.WINDOW.LEAVE_FULLSCREEN);
@@ -417,6 +419,7 @@ contextBridge.exposeInMainWorld('windowAPI', {
   onLeaveFullscreen: windowAPI.onLeaveFullscreen,
   onResized: windowAPI.onResized,
   setFullScreen: windowAPI.setFullScreen,
+  isFullScreen: windowAPI.isFullScreen,
   removeListeners: windowAPI.removeListeners
 });
 

--- a/src/shared/ipc/channels.json
+++ b/src/shared/ipc/channels.json
@@ -11,7 +11,8 @@
     "ENTER_FULLSCREEN": "window:enter-fullscreen",
     "LEAVE_FULLSCREEN": "window:leave-fullscreen",
     "RESIZED": "window:resized",
-    "SET_FULLSCREEN": "window:set-fullscreen"
+    "SET_FULLSCREEN": "window:set-fullscreen",
+    "IS_FULLSCREEN": "window:is-fullscreen"
   },
   "UPDATE": {
     "CHECK": "update:check",

--- a/tests/unit/features/settings/services/fullscreen.service.test.js
+++ b/tests/unit/features/settings/services/fullscreen.service.test.js
@@ -188,16 +188,16 @@ describe('SettingsFullscreenService', () => {
 
   describe('toggleFullscreen', () => {
     it('should enter fullscreen when not in fullscreen', async () => {
-      service.toggleFullscreen();
+      await service.toggleFullscreen();
 
       expect(mockDocumentElement.requestFullscreen).toHaveBeenCalled();
     });
 
-    it('should exit fullscreen when already in fullscreen', () => {
+    it('should exit fullscreen when already in fullscreen', async () => {
       service._isFullscreenActive = true;
       mockDocument.fullscreenElement = mockDocumentElement;
 
-      service.toggleFullscreen();
+      await service.toggleFullscreen();
 
       expect(mockDocument.exitFullscreen).toHaveBeenCalled();
     });
@@ -373,10 +373,10 @@ describe('SettingsFullscreenService', () => {
       service.initialize();
     });
 
-    it('should handle complete fullscreen entry and exit cycle', () => {
+    it('should handle complete fullscreen entry and exit cycle', async () => {
       // Enter fullscreen
       mockDocument.fullscreenElement = null;
-      service.toggleFullscreen();
+      await service.toggleFullscreen();
       expect(mockDocumentElement.requestFullscreen).toHaveBeenCalled();
 
       // Simulate fullscreenchange event
@@ -390,7 +390,7 @@ describe('SettingsFullscreenService', () => {
       );
 
       // Exit fullscreen
-      service.toggleFullscreen();
+      await service.toggleFullscreen();
       expect(mockDocument.exitFullscreen).toHaveBeenCalled();
 
       // Simulate fullscreenchange event


### PR DESCRIPTION
## Summary
- Add `isFullScreen` IPC handler to query actual window fullscreen state
- Sync internal fullscreen state on window resize and initialization
- Handle cases where fullscreen state changes outside the app's control

## Test plan
- [x] All existing tests pass (2150 tests)
- [ ] Verify fullscreen toggle works correctly
- [ ] Verify state syncs after window resize in fullscreen