### PR TITLE
feat(streaming): add auto-stream on device connect setting

### DIFF
--- a/src/renderer/application/app.orchestrator.js
+++ b/src/renderer/application/app.orchestrator.js
@@ -59,8 +59,8 @@ export class AppOrchestrator extends BaseOrchestrator {
     this._wireHighLevelEvents();
 
     // Initialize domain orchestrators
-    await this.deviceOrchestrator.initialize();
     await this.streamingOrchestrator.initialize();
+    await this.deviceOrchestrator.initialize();
     await this.captureOrchestrator.initialize();
 
     // Initialize application orchestrators

--- a/src/renderer/container.js
+++ b/src/renderer/container.js
@@ -479,9 +479,10 @@ function createRendererContainer() {
   // Streaming Orchestrator - Coordinates stream lifecycle
   // Uses appState instead of deviceOrchestrator for decoupling
   // Requires gpuRecordingService to stop recording before GPU cleanup (avoids Skia race)
+  // Requires settingsService for auto-stream on connect feature
   container.registerSingleton(
     'streamingOrchestrator',
-    function (streamingService, appState, streamViewService, audioWarmupService, renderPipelineService, gpuRecordingService, eventBus, loggerFactory) {
+    function (streamingService, appState, streamViewService, audioWarmupService, renderPipelineService, gpuRecordingService, settingsService, eventBus, loggerFactory) {
       return new StreamingOrchestrator({
         streamingService,
         appState,
@@ -489,11 +490,12 @@ function createRendererContainer() {
         audioWarmupService,
         renderPipelineService,
         gpuRecordingService,
+        settingsService,
         eventBus,
         loggerFactory
       });
     },
-    ['streamingService', 'appState', 'streamViewService', 'audioWarmupService', 'renderPipelineService', 'gpuRecordingService', 'eventBus', 'loggerFactory']
+    ['streamingService', 'appState', 'streamViewService', 'audioWarmupService', 'renderPipelineService', 'gpuRecordingService', 'settingsService', 'eventBus', 'loggerFactory']
   );
 
   // Capture Orchestrator - Coordinates screenshot and recording

--- a/src/renderer/features/devices/services/device-connection.service.js
+++ b/src/renderer/features/devices/services/device-connection.service.js
@@ -21,8 +21,10 @@ class DeviceConnectionService extends BaseService {
 
       this.isConnected = connected;
 
-      this.logger.info(`Device status: ${connected ? 'CONNECTED' : 'DISCONNECTED'}`);
-      this.eventBus.publish(EventChannels.DEVICE.STATUS_CHANGED, status);
+      if (changed) {
+        this.logger.info(`Device status: ${connected ? 'CONNECTED' : 'DISCONNECTED'}`);
+        this.eventBus.publish(EventChannels.DEVICE.STATUS_CHANGED, status);
+      }
 
       return { status, changed };
     } catch (error) {

--- a/src/renderer/features/devices/services/device-media.service.js
+++ b/src/renderer/features/devices/services/device-media.service.js
@@ -26,6 +26,7 @@ class DeviceMediaService extends BaseService {
     this._enumerateCooldownMs = TIMING.DEVICE_ENUMERATE_COOLDOWN_MS;
     this._lastEnumerateResult = null;
     this._deviceChangeHandler = null;
+    this._knownSupportedDeviceIds = new Set();
   }
 
   invalidateEnumerationCache() {
@@ -82,6 +83,12 @@ class DeviceMediaService extends BaseService {
         }
 
         this.videoDevices = videoDevices;
+
+        if (videoDevices.length === 0) {
+          this._knownSupportedDeviceIds.clear();
+        } else {
+          this._checkForNewSupportedDevice();
+        }
 
         const result = {
           devices: videoDevices,
@@ -190,10 +197,25 @@ class DeviceMediaService extends BaseService {
 
     this._deviceChangeHandler = async () => {
       this.logger.info('Device change detected');
+      this.invalidateEnumerationCache();
       await onChange();
+      await this.enumerateDevices();
     };
     this.browserMediaService.addEventListener('devicechange', this._deviceChangeHandler);
     this.logger.info('Device change listener set up');
+  }
+
+  _checkForNewSupportedDevice() {
+    for (const device of this.videoDevices) {
+      if (!this._knownSupportedDeviceIds.has(device.deviceId)) {
+        this._knownSupportedDeviceIds.add(device.deviceId);
+        this.logger.info(`New supported device available: ${device.label}`);
+        this.eventBus.publish(EventChannels.DEVICE.SUPPORTED_DEVICE_AVAILABLE, {
+          deviceId: device.deviceId,
+          label: device.label
+        });
+      }
+    }
   }
 
   dispose() {

--- a/src/renderer/features/devices/services/device.orchestrator.js
+++ b/src/renderer/features/devices/services/device.orchestrator.js
@@ -38,8 +38,9 @@ export class DeviceOrchestrator extends BaseOrchestrator {
       () => this._handleDeviceDisconnectedIPC()
     );
 
-    // Check initial device status
+    // Check initial device status and enumerate
     await this.deviceService.updateDeviceStatus();
+    await this.deviceService.enumerateDevices();
   }
 
   /**
@@ -63,6 +64,7 @@ export class DeviceOrchestrator extends BaseOrchestrator {
    */
   async _handleDeviceConnectedIPC() {
     await this._refreshDeviceInfo();
+    await this.deviceService.enumerateDevices();
   }
 
   /**

--- a/src/renderer/features/settings/services/settings.service.js
+++ b/src/renderer/features/settings/services/settings.service.js
@@ -26,7 +26,8 @@ class SettingsService extends BaseService {
       globalBrightness: 1.0,
       performanceMode: false,
       fullscreenOnStartup: false,
-      minimalistFullscreen: false
+      minimalistFullscreen: false,
+      autoStreamOnConnect: false
     };
 
     // Use centralized storage keys
@@ -201,6 +202,25 @@ class SettingsService extends BaseService {
 
     // Emit event
     this.eventBus.publish(EventChannels.SETTINGS.MINIMALIST_FULLSCREEN_CHANGED, enabled);
+  }
+
+  /**
+   * Get auto-stream on connect preference
+   * @returns {boolean} True if auto-stream on connect is enabled
+   */
+  getAutoStreamOnConnect() {
+    const saved = this.storageService?.getItem(this.keys.AUTO_STREAM_ON_CONNECT);
+    return saved !== null ? saved === 'true' : this.defaults.autoStreamOnConnect;
+  }
+
+  /**
+   * Set auto-stream on connect preference
+   * @param {boolean} enabled - Enable auto-stream on connect
+   */
+  setAutoStreamOnConnect(enabled) {
+    this.storageService?.setItem(this.keys.AUTO_STREAM_ON_CONNECT, enabled.toString());
+
+    this.logger.debug(`Auto-stream on connect ${enabled ? 'enabled' : 'disabled'}`);
   }
 }
 

--- a/src/renderer/features/settings/ui/settings-menu.component.js
+++ b/src/renderer/features/settings/ui/settings-menu.component.js
@@ -34,6 +34,7 @@ class SettingsMenuComponent {
     this.toggleButton = elements.settingsBtn;
     this.statusStripCheckbox = elements.settingStatusStrip;
     this.fullscreenOnStartupCheckbox = elements.settingFullscreenOnStartup;
+    this.autoStreamOnConnectCheckbox = elements.settingAutoStreamOnConnect;
     this.minimalistFullscreenCheckbox = elements.settingMinimalistFullscreen;
     this.animationSaverCheckbox = elements.settingAnimationSaver;
     this.disclaimerBtn = elements.disclaimerBtn;
@@ -98,6 +99,13 @@ class SettingsMenuComponent {
       });
     }
 
+    // Auto-stream on connect toggle
+    if (this.autoStreamOnConnectCheckbox) {
+      this._domListeners.add(this.autoStreamOnConnectCheckbox, 'change', () => {
+        this.settingsService.setAutoStreamOnConnect(this.autoStreamOnConnectCheckbox.checked);
+      });
+    }
+
     // Minimalist fullscreen toggle
     if (this.minimalistFullscreenCheckbox) {
       this._domListeners.add(this.minimalistFullscreenCheckbox, 'change', () => {
@@ -132,6 +140,7 @@ class SettingsMenuComponent {
   _loadCurrentSettings() {
     const statusStripVisible = this.settingsService.getStatusStripVisible();
     const fullscreenOnStartupEnabled = this.settingsService.getFullscreenOnStartup?.() ?? false;
+    const autoStreamOnConnectEnabled = this.settingsService.getAutoStreamOnConnect?.() ?? false;
     const minimalistFullscreenEnabled = this.settingsService.getMinimalistFullscreen?.() ?? false;
     const performanceModeEnabled = this.settingsService.getPerformanceMode?.() ?? false;
 
@@ -141,6 +150,10 @@ class SettingsMenuComponent {
 
     if (this.fullscreenOnStartupCheckbox) {
       this.fullscreenOnStartupCheckbox.checked = fullscreenOnStartupEnabled;
+    }
+
+    if (this.autoStreamOnConnectCheckbox) {
+      this.autoStreamOnConnectCheckbox.checked = autoStreamOnConnectEnabled;
     }
 
     if (this.minimalistFullscreenCheckbox) {

--- a/src/renderer/features/streaming/services/streaming.orchestrator.js
+++ b/src/renderer/features/streaming/services/streaming.orchestrator.js
@@ -22,7 +22,7 @@ export class StreamingOrchestrator extends BaseOrchestrator {
   constructor(dependencies) {
     super(
       dependencies,
-      ['streamingService', 'appState', 'streamViewService', 'audioWarmupService', 'renderPipelineService', 'gpuRecordingService', 'eventBus', 'loggerFactory'],
+      ['streamingService', 'appState', 'streamViewService', 'audioWarmupService', 'renderPipelineService', 'gpuRecordingService', 'settingsService', 'eventBus', 'loggerFactory'],
       'StreamingOrchestrator'
     );
   }
@@ -155,7 +155,8 @@ export class StreamingOrchestrator extends BaseOrchestrator {
    */
   _wireDeviceEvents() {
     this.subscribeWithCleanup({
-      [EventChannels.DEVICE.DISCONNECTED_DURING_SESSION]: () => this._handleDeviceDisconnectedDuringStream()
+      [EventChannels.DEVICE.DISCONNECTED_DURING_SESSION]: () => this._handleDeviceDisconnectedDuringStream(),
+      [EventChannels.DEVICE.SUPPORTED_DEVICE_AVAILABLE]: (data) => this._handleSupportedDeviceAvailable(data)
     });
   }
 
@@ -281,6 +282,25 @@ export class StreamingOrchestrator extends BaseOrchestrator {
       this.streamingService.stop().catch(error => {
         this.logger.error('Error stopping stream after device disconnect:', error);
       });
+    }
+  }
+
+  /**
+   * Handle supported device available event for auto-stream on connect
+   * Triggered when browser enumeration detects a new supported device
+   * Bypasses appState.deviceConnected check since browser enumeration confirmed device exists
+   * @param {Object} data - Device data with deviceId and label
+   * @private
+   */
+  async _handleSupportedDeviceAvailable(data) {
+    if (this.settingsService.getAutoStreamOnConnect() && !this.streamingService.isActive()) {
+      this.logger.info(`Auto-starting stream - device available: ${data.label}`);
+      try {
+        await this.streamingService.start(data.deviceId);
+      } catch (error) {
+        this.logger.error('Failed to auto-start stream:', error);
+        this.eventBus.publish(EventChannels.UI.OVERLAY_ERROR, { message: error.message });
+      }
     }
   }
 

--- a/src/renderer/infrastructure/events/event-channels.config.js
+++ b/src/renderer/infrastructure/events/event-channels.config.js
@@ -14,6 +14,7 @@ export const EventChannels = {
   // Device events
   DEVICE: {
     STATUS_CHANGED: 'device:status-changed',
+    SUPPORTED_DEVICE_AVAILABLE: 'device:supported-device-available',
     ENUMERATION_FAILED: 'device:enumeration-failed',
     DISCONNECTED_DURING_SESSION: 'device:disconnected-during-session'
   },

--- a/src/renderer/ui/controller/ui.controller.js
+++ b/src/renderer/ui/controller/ui.controller.js
@@ -73,6 +73,7 @@ class UIController {
       settingsMenuContainer: document.getElementById(DOMSelectors.SETTINGS_MENU_CONTAINER),
       settingStatusStrip: document.getElementById(DOMSelectors.SETTING_STATUS_STRIP),
       settingFullscreenOnStartup: document.getElementById(DOMSelectors.SETTING_FULLSCREEN_ON_STARTUP),
+      settingAutoStreamOnConnect: document.getElementById(DOMSelectors.SETTING_AUTO_STREAM_ON_CONNECT),
       settingMinimalistFullscreen: document.getElementById(DOMSelectors.SETTING_MINIMALIST_FULLSCREEN),
       settingAnimationSaver: document.getElementById(DOMSelectors.SETTING_ANIMATION_SAVER),
       settingRenderPreset: document.getElementById(DOMSelectors.SETTING_RENDER_PRESET),

--- a/src/renderer/ui/templates/header.template.js
+++ b/src/renderer/ui/templates/header.template.js
@@ -48,6 +48,16 @@ export default function createHeaderTemplate() {
                 </label>
                 <label class="settings-item toggle settings-item-with-hint">
                   <span class="settings-item-text">
+                    <span class="settings-item-title">Auto-start stream</span>
+                    <span class="settings-item-hint" id="autoStreamHint">
+                      Automatically start streaming when device connects.
+                    </span>
+                  </span>
+                  <input type="checkbox" id="settingAutoStreamOnConnect" aria-describedby="autoStreamHint">
+                  <span class="toggle-slider"></span>
+                </label>
+                <label class="settings-item toggle settings-item-with-hint">
+                  <span class="settings-item-text">
                     <span class="settings-item-title">Minimalist fullscreen</span>
                     <span class="settings-item-hint" id="minimalistFullscreenHint">
                       Black background while streaming.

--- a/src/shared/config/dom-selectors.config.js
+++ b/src/shared/config/dom-selectors.config.js
@@ -49,6 +49,7 @@ export const DOMSelectors = {
   SETTING_RENDER_PRESET: 'settingRenderPreset',
   SETTING_FULLSCREEN_ON_STARTUP: 'settingFullscreenOnStartup',
   SETTING_MINIMALIST_FULLSCREEN: 'settingMinimalistFullscreen',
+  SETTING_AUTO_STREAM_ON_CONNECT: 'settingAutoStreamOnConnect',
   DISCLAIMER_BTN: 'disclaimerBtn',
   DISCLAIMER_CONTENT: 'disclaimerContent',
 

--- a/src/shared/config/storage-keys.config.js
+++ b/src/shared/config/storage-keys.config.js
@@ -15,7 +15,8 @@ export const SettingsStorageKeys = {
   GLOBAL_BRIGHTNESS: 'globalBrightness',
   PERFORMANCE_MODE: 'performanceMode',
   FULLSCREEN_ON_STARTUP: 'fullscreenOnStartup',
-  MINIMALIST_FULLSCREEN: 'minimalistFullscreen'
+  MINIMALIST_FULLSCREEN: 'minimalistFullscreen',
+  AUTO_STREAM_ON_CONNECT: 'autoStreamOnConnect'
 };
 
 /**
@@ -52,5 +53,6 @@ export const PROTECTED_STORAGE_KEYS = [
   SettingsStorageKeys.GLOBAL_BRIGHTNESS,
   SettingsStorageKeys.PERFORMANCE_MODE,
   SettingsStorageKeys.FULLSCREEN_ON_STARTUP,
-  SettingsStorageKeys.MINIMALIST_FULLSCREEN
+  SettingsStorageKeys.MINIMALIST_FULLSCREEN,
+  SettingsStorageKeys.AUTO_STREAM_ON_CONNECT
 ];

--- a/tests/unit/app/renderer/container.test.js
+++ b/tests/unit/app/renderer/container.test.js
@@ -367,7 +367,7 @@ describe('Renderer Container', () => {
       expect(container.registerSingleton).toHaveBeenCalledWith(
         'streamingOrchestrator',
         expect.any(Function),
-        ['streamingService', 'appState', 'streamViewService', 'audioWarmupService', 'renderPipelineService', 'gpuRecordingService', 'eventBus', 'loggerFactory']
+        ['streamingService', 'appState', 'streamViewService', 'audioWarmupService', 'renderPipelineService', 'gpuRecordingService', 'settingsService', 'eventBus', 'loggerFactory']
       );
     });
 

--- a/tests/unit/features/devices/services/device.orchestrator.test.js
+++ b/tests/unit/features/devices/services/device.orchestrator.test.js
@@ -74,10 +74,11 @@ describe('DeviceOrchestrator', () => {
       );
     });
 
-    it('should check initial device status', async () => {
+    it('should check initial device status and enumerate', async () => {
       await orchestrator.onInitialize();
 
       expect(mockDeviceService.updateDeviceStatus).toHaveBeenCalled();
+      expect(mockDeviceService.enumerateDevices).toHaveBeenCalled();
     });
   });
 
@@ -135,11 +136,10 @@ describe('DeviceOrchestrator', () => {
       expect(mockDeviceService.updateDeviceStatus).toHaveBeenCalled();
     });
 
-    it('should NOT enumerate devices (deferred to streaming start)', async () => {
-      // Camera enumeration is deferred to prevent macOS webcam flicker
+    it('should enumerate devices to detect new supported devices', async () => {
       await orchestrator._handleDeviceConnectedIPC();
 
-      expect(mockDeviceService.enumerateDevices).not.toHaveBeenCalled();
+      expect(mockDeviceService.enumerateDevices).toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/features/settings/services/settings.service.test.js
+++ b/tests/unit/features/settings/services/settings.service.test.js
@@ -288,4 +288,37 @@ describe('SettingsService', () => {
     });
   });
 
+  describe('getAutoStreamOnConnect', () => {
+    it('should return default when not set', () => {
+      expect(service.getAutoStreamOnConnect()).toBe(false);
+    });
+
+    it('should return saved preference (true)', () => {
+      localStorageMock.store['autoStreamOnConnect'] = 'true';
+      expect(service.getAutoStreamOnConnect()).toBe(true);
+    });
+
+    it('should return saved preference (false)', () => {
+      localStorageMock.store['autoStreamOnConnect'] = 'false';
+      expect(service.getAutoStreamOnConnect()).toBe(false);
+    });
+  });
+
+  describe('setAutoStreamOnConnect', () => {
+    it('should save preference to localStorage', () => {
+      service.setAutoStreamOnConnect(true);
+      expect(localStorageMock.setItem).toHaveBeenCalledWith('autoStreamOnConnect', 'true');
+    });
+
+    it('should log preference change (enabled)', () => {
+      service.setAutoStreamOnConnect(true);
+      expect(mockLogger.debug).toHaveBeenCalledWith('Auto-stream on connect enabled');
+    });
+
+    it('should log preference change (disabled)', () => {
+      service.setAutoStreamOnConnect(false);
+      expect(mockLogger.debug).toHaveBeenCalledWith('Auto-stream on connect disabled');
+    });
+  });
+
 });

--- a/tests/unit/features/streaming/services/streaming.orchestrator.test.js
+++ b/tests/unit/features/streaming/services/streaming.orchestrator.test.js
@@ -15,6 +15,7 @@ describe('StreamingOrchestrator', () => {
   let mockLogger;
   let mockStreamingRenderPipelineService;
   let mockCaptureGpuRecordingService;
+  let mockSettingsService;
 
   beforeEach(() => {
     mockStreamingService = {
@@ -70,6 +71,10 @@ describe('StreamingOrchestrator', () => {
       stop: vi.fn()
     };
 
+    mockSettingsService = {
+      getAutoStreamOnConnect: vi.fn().mockReturnValue(false)
+    };
+
     orchestrator = new StreamingOrchestrator({
       streamingService: mockStreamingService,
       appState: mockAppState,
@@ -77,6 +82,7 @@ describe('StreamingOrchestrator', () => {
       audioWarmupService: mockStreamingAudioWarmupService,
       renderPipelineService: mockStreamingRenderPipelineService,
       gpuRecordingService: mockCaptureGpuRecordingService,
+      settingsService: mockSettingsService,
       eventBus: mockEventBus,
       loggerFactory: { create: vi.fn(() => mockLogger) }
     });
@@ -96,6 +102,7 @@ describe('StreamingOrchestrator', () => {
       expect(mockEventBus.subscribe).toHaveBeenCalledWith('performance:render-mode-changed', expect.any(Function));
       expect(mockEventBus.subscribe).toHaveBeenCalledWith('performance:state-changed', expect.any(Function));
       expect(mockEventBus.subscribe).toHaveBeenCalledWith('device:disconnected-during-session', expect.any(Function));
+      expect(mockEventBus.subscribe).toHaveBeenCalledWith('device:supported-device-available', expect.any(Function));
       expect(mockEventBus.subscribe).toHaveBeenCalledWith('render:canvas-expired', expect.any(Function));
       expect(mockStreamingRenderPipelineService.initialize).toHaveBeenCalled();
     });
@@ -312,6 +319,72 @@ describe('StreamingOrchestrator', () => {
       orchestrator._handleDeviceDisconnectedDuringStream();
 
       expect(mockStreamingService.stop).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('_handleSupportedDeviceAvailable', () => {
+    const mockDeviceData = { deviceId: 'test-device-id', label: 'Test Device' };
+
+    it('should auto-start stream when device becomes available and setting enabled', async () => {
+      mockStreamingService.isActive.mockReturnValue(false);
+      mockSettingsService.getAutoStreamOnConnect.mockReturnValue(true);
+
+      await orchestrator._handleSupportedDeviceAvailable(mockDeviceData);
+
+      expect(mockLogger.info).toHaveBeenCalledWith('Auto-starting stream - device available: Test Device');
+      expect(mockStreamingService.start).toHaveBeenCalledWith('test-device-id');
+    });
+
+    it('should bypass appState.deviceConnected check (browser enumeration is source of truth)', async () => {
+      mockAppState.deviceConnected = false;
+      mockStreamingService.isActive.mockReturnValue(false);
+      mockSettingsService.getAutoStreamOnConnect.mockReturnValue(true);
+
+      await orchestrator._handleSupportedDeviceAvailable(mockDeviceData);
+
+      expect(mockStreamingService.start).toHaveBeenCalledWith('test-device-id');
+    });
+
+    it('should not auto-start when setting disabled', async () => {
+      mockStreamingService.isActive.mockReturnValue(false);
+      mockSettingsService.getAutoStreamOnConnect.mockReturnValue(false);
+
+      await orchestrator._handleSupportedDeviceAvailable(mockDeviceData);
+
+      expect(mockStreamingService.start).not.toHaveBeenCalled();
+    });
+
+    it('should not auto-start when streaming service is active', async () => {
+      mockStreamingService.isActive.mockReturnValue(true);
+      mockSettingsService.getAutoStreamOnConnect.mockReturnValue(true);
+
+      await orchestrator._handleSupportedDeviceAvailable(mockDeviceData);
+
+      expect(mockStreamingService.start).not.toHaveBeenCalled();
+    });
+
+    it('should handle rapid duplicate device available events gracefully', async () => {
+      mockStreamingService.isActive.mockReturnValue(false);
+      mockSettingsService.getAutoStreamOnConnect.mockReturnValue(true);
+
+      await orchestrator._handleSupportedDeviceAvailable(mockDeviceData);
+
+      mockStreamingService.isActive.mockReturnValue(true);
+
+      await orchestrator._handleSupportedDeviceAvailable(mockDeviceData);
+
+      expect(mockStreamingService.start).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle start error gracefully', async () => {
+      mockStreamingService.isActive.mockReturnValue(false);
+      mockSettingsService.getAutoStreamOnConnect.mockReturnValue(true);
+      mockStreamingService.start.mockRejectedValue(new Error('Start failed'));
+
+      await orchestrator._handleSupportedDeviceAvailable(mockDeviceData);
+
+      expect(mockLogger.error).toHaveBeenCalledWith('Failed to auto-start stream:', expect.any(Error));
+      expect(mockEventBus.publish).toHaveBeenCalledWith('ui:overlay-error', { message: 'Start failed' });
     });
   });
 


### PR DESCRIPTION
## Summary
- Add toggle setting to automatically start streaming when a supported device connects
- Bypasses the overlay click requirement when enabled
- Works both at app startup (device already connected) and runtime (device connected later)

## Implementation
- New `autoStreamOnConnect` setting persisted to localStorage
- `DeviceMediaService` tracks and publishes `SUPPORTED_DEVICE_AVAILABLE` event when browser enumeration detects a new supported device
- `StreamingOrchestrator` subscribes to the event and auto-starts when setting is enabled
- Bypasses `appState.deviceConnected` check since browser enumeration is the source of truth for device availability
- Initialize `StreamingOrchestrator` before `DeviceOrchestrator` to ensure event subscription happens before device detection

## Test plan
- [x] Toggle setting persists across app restarts
- [x] Auto-stream triggers when device connected at app startup
- [x] Auto-stream triggers when device connected while app running
- [x] Manual stream start still works when setting disabled
- [x] All 2169 unit tests pass
- [x] Lint passes