### PR TITLE
style(settings): use pink scrollbar in settings menu

### DIFF
--- a/src/renderer/assets/styles/modals.css
+++ b/src/renderer/assets/styles/modals.css
@@ -61,6 +61,14 @@
   overflow-y: auto;
 }
 
+.settings-menu::-webkit-scrollbar-thumb {
+  background: rgba(255, 0, 128, 0.5);
+}
+
+.settings-menu::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 0, 128, 0.8);
+}
+
 /* Main settings area with generous spacing */
 .settings-section.settings-main {
   padding: 20px var(--space-lg);


### PR DESCRIPTION
## Summary
- Updates settings menu scrollbar to use the pink primary color (`#ff0080`) instead of the rainbow gradient
- Matches the visual style of the update button for consistency

## Test plan
- [x] Verified scrollbar color matches primary pink
- [x] All 2169 tests pass