### PR TITLE
feat(notes): add drag-to-resize for notes list divider

### DIFF
--- a/src/renderer/assets/styles/notes.css
+++ b/src/renderer/assets/styles/notes.css
@@ -313,6 +313,7 @@ body:not(.streaming-mode) .notes-panel {
    ===================================================== */
 
 .notes-panel-content {
+  --notes-list-width: 130px;
   flex: 1;
   display: flex;
   min-height: 0;
@@ -321,7 +322,7 @@ body:not(.streaming-mode) .notes-panel {
 
 /* List wrapper - handles collapse animation */
 .notes-list-wrapper {
-  width: 130px;
+  width: var(--notes-list-width, 130px);
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
@@ -396,9 +397,11 @@ body:not(.streaming-mode) .notes-panel {
   font-size: var(--font-size-xs);
   font-weight: 500;
   color: rgba(255, 255, 255, 0.72);
-  white-space: nowrap;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
   overflow: hidden;
-  text-overflow: ellipsis;
+  overflow-wrap: break-word;
   transition: color 0.15s ease;
 }
 
@@ -556,6 +559,22 @@ body:not(.streaming-mode) .notes-panel {
   background: rgba(var(--color-info-rgb), 0.5);
   height: 36px;
   box-shadow: 0 0 8px rgba(var(--color-info-rgb), 0.3);
+}
+
+/* Dragging state */
+.notes-list-toggle.dragging {
+  background: rgba(var(--color-info-rgb), 0.1);
+}
+
+.notes-list-toggle.dragging .toggle-handle {
+  background: rgba(var(--color-info-rgb), 0.7);
+  height: 44px;
+  box-shadow: 0 0 12px rgba(var(--color-info-rgb), 0.4);
+}
+
+/* Disable transition during drag for responsive feedback */
+.notes-panel-content:has(.notes-list-toggle.dragging) .notes-list-wrapper {
+  transition: none;
 }
 
 /* Visual indicator when collapsed */

--- a/src/renderer/features/notes/ui/notes-panel.component.js
+++ b/src/renderer/features/notes/ui/notes-panel.component.js
@@ -20,6 +20,12 @@ const DELETE_HOLD_MS = 2000;
 // Autocomplete debounce
 const AUTOCOMPLETE_DEBOUNCE_MS = 100;
 
+// List resize constraints
+const DRAG_THRESHOLD = 3;
+const LIST_WIDTH_MIN = 80;
+const LIST_WIDTH_MAX = 200;
+const LIST_WIDTH_DEFAULT = 130;
+
 class NotesPanelComponent {
   constructor({ notesService, eventBus, logger }) {
     this.notesService = notesService;
@@ -34,6 +40,14 @@ class NotesPanelComponent {
     this.isGameFilterOpen = false;
     this.collapsedGameGroups = new Set();
     this.autocompleteHighlightIndex = -1;
+
+    // Drag resize state
+    this._isDragging = false;
+    this._dragStartX = 0;
+    this._dragStartWidth = 0;
+    this._customListWidth = LIST_WIDTH_DEFAULT;
+    this._boundDragMove = null;
+    this._boundDragEnd = null;
 
     // Debounce timers
     this._saveTimeout = null;
@@ -362,15 +376,73 @@ class NotesPanelComponent {
   }
 
   /**
-   * Setup list toggle (collapse/expand divider)
+   * Setup list toggle with drag-to-resize and click-to-collapse
    * @private
    */
   _setupListToggle() {
     if (!this.elements.notesListToggle) return;
 
-    this._domListeners.add(this.elements.notesListToggle, 'click', () => {
-      this._toggleListVisibility();
-    });
+    const getClientX = (e) => e.touches?.[0]?.clientX ?? e.clientX;
+
+    const startDrag = (e) => {
+      e.preventDefault();
+
+      this._dragStartX = getClientX(e);
+      this._dragStartWidth = this._getListWidth();
+      this._isDragging = false;
+
+      this._boundDragMove = handleMove;
+      this._boundDragEnd = endDrag;
+
+      document.addEventListener('mousemove', handleMove);
+      document.addEventListener('mouseup', endDrag);
+      document.addEventListener('touchmove', handleMove, { passive: false });
+      document.addEventListener('touchend', endDrag);
+      document.addEventListener('touchcancel', endDrag);
+
+      document.body.style.cursor = 'col-resize';
+      document.body.style.userSelect = 'none';
+    };
+
+    const handleMove = (e) => {
+      const currentX = getClientX(e);
+      const delta = currentX - this._dragStartX;
+
+      if (!this._isDragging && Math.abs(delta) >= DRAG_THRESHOLD) {
+        this._isDragging = true;
+        this.elements.notesListToggle?.classList.add('dragging');
+      }
+
+      if (this._isDragging) {
+        e.preventDefault();
+        const newWidth = Math.min(
+          LIST_WIDTH_MAX,
+          Math.max(LIST_WIDTH_MIN, this._dragStartWidth + delta)
+        );
+        this._setListWidth(newWidth);
+      }
+    };
+
+    const endDrag = () => {
+      this._cleanupDragListeners();
+
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+      this.elements.notesListToggle?.classList.remove('dragging');
+
+      if (!this._isDragging) {
+        this._toggleListVisibility();
+      } else {
+        this._customListWidth = this._getListWidth();
+      }
+
+      this._isDragging = false;
+      this._boundDragMove = null;
+      this._boundDragEnd = null;
+    };
+
+    this._domListeners.add(this.elements.notesListToggle, 'mousedown', startDrag);
+    this._domListeners.add(this.elements.notesListToggle, 'touchstart', startDrag, { passive: false });
   }
 
   /**
@@ -385,10 +457,35 @@ class NotesPanelComponent {
 
     if (this.isListVisible) {
       content.classList.remove(CSSClasses.LIST_COLLAPSED);
+      this._setListWidth(this._customListWidth);
       this.elements.notesListToggle?.setAttribute('aria-expanded', 'true');
     } else {
       content.classList.add(CSSClasses.LIST_COLLAPSED);
       this.elements.notesListToggle?.setAttribute('aria-expanded', 'false');
+    }
+  }
+
+  _getListWidth() {
+    const listWrapper = this.elements.notesPanel?.querySelector('.notes-list-wrapper');
+    if (!listWrapper) return LIST_WIDTH_DEFAULT;
+    return listWrapper.offsetWidth;
+  }
+
+  _setListWidth(width) {
+    const content = this.elements.notesPanel?.querySelector('.notes-panel-content');
+    if (!content) return;
+    content.style.setProperty('--notes-list-width', `${width}px`);
+  }
+
+  _cleanupDragListeners() {
+    if (this._boundDragMove) {
+      document.removeEventListener('mousemove', this._boundDragMove);
+      document.removeEventListener('touchmove', this._boundDragMove);
+    }
+    if (this._boundDragEnd) {
+      document.removeEventListener('mouseup', this._boundDragEnd);
+      document.removeEventListener('touchend', this._boundDragEnd);
+      document.removeEventListener('touchcancel', this._boundDragEnd);
     }
   }
 
@@ -1279,6 +1376,12 @@ class NotesPanelComponent {
       this._resizeObserver.disconnect();
       this._resizeObserver = null;
     }
+
+    // Clean up drag state
+    this._cleanupDragListeners();
+    this._isDragging = false;
+    this._boundDragMove = null;
+    this._boundDragEnd = null;
 
     // Remove DOM listeners
     this._domListeners.removeAll();


### PR DESCRIPTION
## Summary
- Add drag functionality to resize notes list width (80-200px range)
- Preserve existing click-to-toggle collapse/expand behavior
- Allow note titles to wrap to 2 lines with word-break

## Changes
- **Drag-to-resize**: Drag the divider to adjust list width between 80-200px
- **Click vs drag detection**: 3px movement threshold distinguishes click from drag
- **Touch support**: Works with both mouse and touch events
- **Visual feedback**: Enhanced handle styles during drag
- **Width persistence**: Custom width restored when expanding from collapsed state
- **Title wrapping**: Note titles in list wrap to 2 lines before truncating with ellipsis

## Test plan
- [ ] Click divider to toggle collapse/expand (existing behavior)
- [ ] Drag divider to resize list width
- [ ] Verify width constraints (min 80px, max 200px)
- [ ] Collapse and expand - verify custom width is restored
- [ ] Test on touch device
- [ ] Verify long note titles wrap to 2 lines