### PR TITLE
fix(build): respect --arch flag for Linux builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,18 +143,9 @@
     },
     "linux": {
       "target": [
-        {
-          "target": "AppImage",
-          "arch": ["x64", "arm64"]
-        },
-        {
-          "target": "deb",
-          "arch": ["x64", "arm64"]
-        },
-        {
-          "target": "tar.gz",
-          "arch": ["x64", "arm64"]
-        }
+        "AppImage",
+        "deb",
+        "tar.gz"
       ],
       "category": "Utility",
       "icon": "assets/icon.png",


### PR DESCRIPTION
## Summary
- Remove explicit arch arrays from Linux electron-builder targets
- CLI flags (`--arm64`, `--x64`) are now respected for local builds
- CI workflow unaffected (uses explicit `target:arch` syntax)

## Problem
When running `npm run build:linux -- --arm64` on an ARM64 machine, electron-builder would:
1. Build ARM64 artifacts (success)
2. Attempt x64 build (failure with `-m64` compiler flag error)

The `arch: ["x64", "arm64"]` arrays in package.json caused both architectures to be built regardless of CLI flags.

## Solution
Simplify Linux targets to strings without arch arrays:
```json
"target": ["AppImage", "deb", "tar.gz"]
```

This allows:
- `npm run build:linux` → builds for current system architecture
- `npm run build:linux -- --arm64` → builds ARM64 only
- `npm run build:linux -- --x64` → builds x64 only

## Test plan
- [ ] Verify `npm run build:linux -- --arm64` only builds ARM64 artifacts
- [ ] Verify CI release workflow still builds all platform/arch combinations
- [ ] Verify local x64 build works with `npm run build:linux -- --x64`