### PR TITLE
refactor(streaming): extract audio orchestration into dedicated orchestrator

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,18 +143,9 @@
     },
     "linux": {
       "target": [
-        {
-          "target": "AppImage",
-          "arch": ["x64", "arm64"]
-        },
-        {
-          "target": "deb",
-          "arch": ["x64", "arm64"]
-        },
-        {
-          "target": "tar.gz",
-          "arch": ["x64", "arm64"]
-        }
+        "AppImage",
+        "deb",
+        "tar.gz"
       ],
       "category": "Utility",
       "icon": "assets/icon.png",

--- a/src/renderer/application/app.orchestrator.js
+++ b/src/renderer/application/app.orchestrator.js
@@ -17,6 +17,7 @@ export class AppOrchestrator extends BaseOrchestrator {
    * @param {Object} dependencies - Injected dependencies
    * @param {DeviceOrchestrator} dependencies.deviceOrchestrator - Device management
    * @param {StreamingOrchestrator} dependencies.streamingOrchestrator - Stream management
+   * @param {StreamingAudioOrchestrator} dependencies.streamingAudioOrchestrator - Audio stream lifecycle
    * @param {CaptureOrchestrator} dependencies.captureOrchestrator - Screenshot/recording
    * @param {PreferencesOrchestrator} dependencies.preferencesOrchestrator - User preferences
    * @param {DisplayModeOrchestrator} dependencies.displayModeOrchestrator - Display modes
@@ -34,6 +35,7 @@ export class AppOrchestrator extends BaseOrchestrator {
       [
         'deviceOrchestrator',
         'streamingOrchestrator',
+        'streamingAudioOrchestrator',
         'captureOrchestrator',
         'preferencesOrchestrator',
         'displayModeOrchestrator',
@@ -59,6 +61,7 @@ export class AppOrchestrator extends BaseOrchestrator {
     this._wireHighLevelEvents();
 
     // Initialize domain orchestrators
+    await this.streamingAudioOrchestrator.initialize();
     await this.streamingOrchestrator.initialize();
     await this.deviceOrchestrator.initialize();
     await this.captureOrchestrator.initialize();
@@ -150,6 +153,7 @@ export class AppOrchestrator extends BaseOrchestrator {
       ['updateOrchestrator', this.updateOrchestrator],
       ['displayModeOrchestrator', this.displayModeOrchestrator],
       ['preferencesOrchestrator', this.preferencesOrchestrator],
+      ['streamingAudioOrchestrator', this.streamingAudioOrchestrator],
       ['streamingOrchestrator', this.streamingOrchestrator],
       ['captureOrchestrator', this.captureOrchestrator],
       ['deviceOrchestrator', this.deviceOrchestrator]

--- a/src/renderer/container.js
+++ b/src/renderer/container.js
@@ -48,6 +48,7 @@ import { DeviceChromaticAdapter } from '@renderer/features/devices/adapters/chro
 // Features: Streaming
 import { StreamingService } from '@renderer/features/streaming/services/streaming.service.js';
 import { StreamingOrchestrator } from '@renderer/features/streaming/services/streaming.orchestrator.js';
+import { StreamingAudioOrchestrator } from '@renderer/features/streaming/services/streaming-audio.orchestrator.js';
 import { StreamingAdapterFactory } from '@renderer/features/streaming/factories/streaming-adapter.factory.js';
 import { StreamingRendererFactory } from '@renderer/features/streaming/factories/streaming-renderer.factory.js';
 import { StreamingCanvasRenderer } from '@renderer/features/streaming/rendering/streaming-canvas-renderer.class.js';
@@ -644,18 +645,32 @@ function createRendererContainer() {
     ['deviceService', 'deviceIpcAdapter', 'deviceOperationSequencer', 'eventBus', 'loggerFactory']
   );
 
+  // Streaming Audio Orchestrator - Coordinates audio warm-up and fallback
+  container.registerSingleton(
+    'streamingAudioOrchestrator',
+    function (streamingAudioPipelineService, streamViewService, appState, eventBus, loggerFactory) {
+      return new StreamingAudioOrchestrator({
+        streamingAudioPipelineService,
+        streamViewService,
+        appState,
+        eventBus,
+        loggerFactory
+      });
+    },
+    ['streamingAudioPipelineService', 'streamViewService', 'appState', 'eventBus', 'loggerFactory']
+  );
+
   // Streaming Orchestrator - Coordinates stream lifecycle
   // Uses appState instead of deviceOrchestrator for decoupling
   // Requires gpuRecordingService to stop recording before GPU cleanup (avoids Skia race)
   // Requires settingsService for auto-stream on connect feature
   container.registerSingleton(
     'streamingOrchestrator',
-    function (streamingService, appState, streamViewService, streamingAudioPipelineService, renderPipelineService, gpuRecordingService, settingsService, eventBus, loggerFactory) {
+    function (streamingService, appState, streamViewService, renderPipelineService, gpuRecordingService, settingsService, eventBus, loggerFactory) {
       return new StreamingOrchestrator({
         streamingService,
         appState,
         streamViewService,
-        streamingAudioPipelineService,
         renderPipelineService,
         gpuRecordingService,
         settingsService,
@@ -663,7 +678,7 @@ function createRendererContainer() {
         loggerFactory
       });
     },
-    ['streamingService', 'appState', 'streamViewService', 'streamingAudioPipelineService', 'renderPipelineService', 'gpuRecordingService', 'settingsService', 'eventBus', 'loggerFactory']
+    ['streamingService', 'appState', 'streamViewService', 'renderPipelineService', 'gpuRecordingService', 'settingsService', 'eventBus', 'loggerFactory']
   );
 
   // Capture Orchestrator - Coordinates screenshot and recording
@@ -863,6 +878,7 @@ function createRendererContainer() {
     function (
       deviceOrchestrator,
       streamingOrchestrator,
+      streamingAudioOrchestrator,
       captureOrchestrator,
       preferencesOrchestrator,
       displayModeOrchestrator,
@@ -877,6 +893,7 @@ function createRendererContainer() {
       return new AppOrchestrator({
         deviceOrchestrator,
         streamingOrchestrator,
+        streamingAudioOrchestrator,
         captureOrchestrator,
         preferencesOrchestrator,
         displayModeOrchestrator,
@@ -892,6 +909,7 @@ function createRendererContainer() {
     [
       'deviceOrchestrator',
       'streamingOrchestrator',
+      'streamingAudioOrchestrator',
       'captureOrchestrator',
       'preferencesOrchestrator',
       'displayModeOrchestrator',

--- a/src/renderer/features/streaming/audio/streaming-audio-pipeline.service.js
+++ b/src/renderer/features/streaming/audio/streaming-audio-pipeline.service.js
@@ -31,6 +31,7 @@ export class StreamingAudioPipelineService extends BaseService {
     this._unmuteTimeout = null;
     this._energyTimer = null;
     this._trackUnmuteHandler = null;
+    this._startPromise = null;
 
     this._unsubscribeVolume = this.eventBus.subscribe(
       EventChannels.SETTINGS.VOLUME_CHANGED,
@@ -39,6 +40,27 @@ export class StreamingAudioPipelineService extends BaseService {
   }
 
   async start(stream) {
+    if (this._startPromise && this._stream === stream) {
+      return this._startPromise;
+    }
+
+    if (this._stream === stream && this._audioContext && this._audioContext.state !== 'closed') {
+      return this._isReady;
+    }
+
+    const startPromise = this._startInternal(stream);
+    this._startPromise = startPromise;
+
+    try {
+      return await startPromise;
+    } finally {
+      if (this._startPromise === startPromise) {
+        this._startPromise = null;
+      }
+    }
+  }
+
+  async _startInternal(stream) {
     this.stop();
 
     if (!stream) {
@@ -129,6 +151,7 @@ export class StreamingAudioPipelineService extends BaseService {
 
   stop() {
     this._warmupToken += 1;
+    this._startPromise = null;
     this._isReady = false;
 
     this._clearTimers();

--- a/src/renderer/features/streaming/services/streaming-audio.orchestrator.js
+++ b/src/renderer/features/streaming/services/streaming-audio.orchestrator.js
@@ -1,0 +1,83 @@
+/**
+ * Streaming Audio Orchestrator
+ *
+ * Coordinates audio pipeline lifecycle for active streams.
+ * Keeps audio warm-up and fallback handling isolated from streaming orchestration.
+ */
+
+import { BaseOrchestrator } from '@shared/base/orchestrator.base.js';
+import { EventChannels } from '@renderer/infrastructure/events/event-channels.config.js';
+
+export class StreamingAudioOrchestrator extends BaseOrchestrator {
+  constructor(dependencies) {
+    super(
+      dependencies,
+      ['streamingAudioPipelineService', 'streamViewService', 'appState', 'eventBus', 'loggerFactory'],
+      'StreamingAudioOrchestrator'
+    );
+
+    this._activeStream = null;
+    this._fallbackUnmuted = false;
+  }
+
+  /**
+   * Initialize audio orchestrator
+   */
+  async onInitialize() {
+    this.subscribeWithCleanup({
+      [EventChannels.STREAM.STARTED]: (data) => this._handleStreamStarted(data),
+      [EventChannels.STREAM.STOPPED]: () => this._handleStreamStopped(),
+      [EventChannels.STREAM.ERROR]: () => this._handleStreamStopped()
+    });
+  }
+
+  _handleStreamStarted(data) {
+    const stream = data?.stream;
+    if (!stream) return;
+
+    if (this._activeStream === stream) {
+      this.logger.debug('Audio pipeline already attached to stream; skipping re-init');
+      return;
+    }
+
+    this._activeStream = stream;
+    this._fallbackUnmuted = false;
+    this._initializeAudioPipeline(stream);
+  }
+
+  _handleStreamStopped() {
+    this._activeStream = null;
+    this._fallbackUnmuted = false;
+    this.streamingAudioPipelineService.stop();
+  }
+
+  /**
+   * Initialize audio pipeline with fallback to video element audio
+   * @param {MediaStream} stream - The media stream
+   * @private
+   */
+  _initializeAudioPipeline(stream) {
+    const hasAudio = stream?.getAudioTracks?.().length > 0;
+
+    this.streamingAudioPipelineService.start(stream)
+      .then((ready) => {
+        if (this._activeStream !== stream) return;
+        if (ready || !hasAudio || !this.appState.isStreaming) return;
+        this._applyVideoAudioFallback();
+      })
+      .catch((error) => {
+        if (this._activeStream !== stream) return;
+        if (hasAudio && this.appState.isStreaming) {
+          this.logger.warn('Audio warm-up error - falling back to video element audio', error);
+          this._applyVideoAudioFallback();
+        }
+      });
+  }
+
+  _applyVideoAudioFallback() {
+    if (this._fallbackUnmuted) return;
+    this._fallbackUnmuted = true;
+    this.logger.warn('Audio warm-up failed - falling back to video element audio');
+    this.streamViewService.setMuted(false);
+  }
+}

--- a/src/renderer/features/streaming/services/streaming.orchestrator.js
+++ b/src/renderer/features/streaming/services/streaming.orchestrator.js
@@ -22,7 +22,7 @@ export class StreamingOrchestrator extends BaseOrchestrator {
   constructor(dependencies) {
     super(
       dependencies,
-      ['streamingService', 'appState', 'streamViewService', 'streamingAudioPipelineService', 'renderPipelineService', 'gpuRecordingService', 'settingsService', 'eventBus', 'loggerFactory'],
+      ['streamingService', 'appState', 'streamViewService', 'renderPipelineService', 'gpuRecordingService', 'settingsService', 'eventBus', 'loggerFactory'],
       'StreamingOrchestrator'
     );
   }
@@ -173,7 +173,6 @@ export class StreamingOrchestrator extends BaseOrchestrator {
     // No need to manually update appState.setStreaming() anymore
 
     this.streamViewService.attachMutedStream(stream);
-    this._initializeAudioPipeline(stream);
 
     // Update UI for streaming mode via event
     this.eventBus.publish(EventChannels.UI.STREAMING_MODE, { enabled: true });
@@ -209,29 +208,6 @@ export class StreamingOrchestrator extends BaseOrchestrator {
   }
 
   /**
-   * Initialize audio pipeline with fallback to video element audio
-   * @param {MediaStream} stream - The media stream
-   * @private
-   */
-  _initializeAudioPipeline(stream) {
-    const hasAudio = stream?.getAudioTracks?.().length > 0;
-
-    this.streamingAudioPipelineService.start(stream)
-      .then((ready) => {
-        if (!ready && hasAudio && this.appState.isStreaming) {
-          this.logger.warn('Audio warm-up failed - falling back to video element audio');
-          this.streamViewService.setMuted(false);
-        }
-      })
-      .catch((error) => {
-        if (hasAudio && this.appState.isStreaming) {
-          this.logger.warn('Audio warm-up error - falling back to video element audio', error);
-          this.streamViewService.setMuted(false);
-        }
-      });
-  }
-
-  /**
    * Handle stream stopped event
    * @private
    */
@@ -247,7 +223,6 @@ export class StreamingOrchestrator extends BaseOrchestrator {
 
     // Stop rendering (GPU or Canvas2D)
     this.renderPipelineService.stopPipeline();
-    this.streamingAudioPipelineService.stop();
     this.streamViewService.clearStream();
 
     // Note: App state automatically derives isStreaming from StreamingService
@@ -267,7 +242,6 @@ export class StreamingOrchestrator extends BaseOrchestrator {
    */
   _handleStreamError(error) {
     this.logger.error('Stream error:', error);
-    this.streamingAudioPipelineService.stop();
     this.eventBus.publish(EventChannels.UI.STATUS_MESSAGE, { message: `Error: ${error.message}`, type: 'error' });
     this.eventBus.publish(EventChannels.UI.OVERLAY_ERROR, { message: error.message });
   }
@@ -310,7 +284,6 @@ export class StreamingOrchestrator extends BaseOrchestrator {
    */
   async onCleanup() {
     this.renderPipelineService.cleanup();
-    this.streamingAudioPipelineService.cleanup();
 
     if (this.streamingService.isActive()) {
       try {

--- a/tests/unit/app/renderer/container.test.js
+++ b/tests/unit/app/renderer/container.test.js
@@ -492,13 +492,23 @@ describe('Renderer Container', () => {
       );
     });
 
+    it('should register streamingAudioOrchestrator singleton', () => {
+      const container = containerModule.createRendererContainer();
+
+      expect(container.registerSingleton).toHaveBeenCalledWith(
+        'streamingAudioOrchestrator',
+        expect.any(Function),
+        ['streamingAudioPipelineService', 'streamViewService', 'appState', 'eventBus', 'loggerFactory']
+      );
+    });
+
     it('should register streamingOrchestrator singleton', () => {
       const container = containerModule.createRendererContainer();
 
       expect(container.registerSingleton).toHaveBeenCalledWith(
         'streamingOrchestrator',
         expect.any(Function),
-        ['streamingService', 'appState', 'streamViewService', 'streamingAudioPipelineService', 'renderPipelineService', 'gpuRecordingService', 'settingsService', 'eventBus', 'loggerFactory']
+        ['streamingService', 'appState', 'streamViewService', 'renderPipelineService', 'gpuRecordingService', 'settingsService', 'eventBus', 'loggerFactory']
       );
     });
 
@@ -518,7 +528,7 @@ describe('Renderer Container', () => {
       expect(container.registerSingleton).toHaveBeenCalledWith(
         'appOrchestrator',
         expect.any(Function),
-        expect.arrayContaining(['deviceOrchestrator', 'streamingOrchestrator', 'captureOrchestrator'])
+        expect.arrayContaining(['deviceOrchestrator', 'streamingOrchestrator', 'streamingAudioOrchestrator', 'captureOrchestrator'])
       );
     });
   });

--- a/tests/unit/features/streaming/services/streaming-audio.orchestrator.test.js
+++ b/tests/unit/features/streaming/services/streaming-audio.orchestrator.test.js
@@ -1,0 +1,209 @@
+/**
+ * StreamingAudioOrchestrator Unit Tests
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { StreamingAudioOrchestrator } from '@renderer/features/streaming/services/streaming-audio.orchestrator.js';
+
+describe('StreamingAudioOrchestrator', () => {
+  let orchestrator;
+  let mockStreamingAudioPipelineService;
+  let mockStreamViewService;
+  let mockAppState;
+  let mockEventBus;
+  let mockLogger;
+
+  beforeEach(() => {
+    mockStreamingAudioPipelineService = {
+      start: vi.fn().mockResolvedValue(true),
+      stop: vi.fn()
+    };
+
+    mockStreamViewService = {
+      setMuted: vi.fn()
+    };
+
+    mockAppState = {
+      isStreaming: false
+    };
+
+    mockEventBus = {
+      publish: vi.fn(),
+      subscribe: vi.fn(() => vi.fn())
+    };
+
+    mockLogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    };
+
+    orchestrator = new StreamingAudioOrchestrator({
+      streamingAudioPipelineService: mockStreamingAudioPipelineService,
+      streamViewService: mockStreamViewService,
+      appState: mockAppState,
+      eventBus: mockEventBus,
+      loggerFactory: { create: vi.fn(() => mockLogger) }
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('onInitialize', () => {
+    it('should subscribe to stream events', async () => {
+      await orchestrator.onInitialize();
+
+      expect(mockEventBus.subscribe).toHaveBeenCalledWith('stream:started', expect.any(Function));
+      expect(mockEventBus.subscribe).toHaveBeenCalledWith('stream:stopped', expect.any(Function));
+      expect(mockEventBus.subscribe).toHaveBeenCalledWith('stream:error', expect.any(Function));
+    });
+  });
+
+  describe('_handleStreamStarted', () => {
+    it('should initialize audio pipeline with stream', () => {
+      const mockStream = { getAudioTracks: vi.fn(() => [{ id: 'audio-1' }]) };
+
+      orchestrator._handleStreamStarted({ stream: mockStream });
+
+      expect(mockStreamingAudioPipelineService.start).toHaveBeenCalledWith(mockStream);
+    });
+
+    it('should skip re-init when same stream already attached', () => {
+      const mockStream = { getAudioTracks: vi.fn(() => [{ id: 'audio-1' }]) };
+
+      orchestrator._handleStreamStarted({ stream: mockStream });
+      orchestrator._handleStreamStarted({ stream: mockStream });
+
+      expect(mockStreamingAudioPipelineService.start).toHaveBeenCalledTimes(1);
+      expect(mockLogger.debug).toHaveBeenCalledWith('Audio pipeline already attached to stream; skipping re-init');
+    });
+
+    it('should do nothing when no stream provided', () => {
+      orchestrator._handleStreamStarted({});
+      orchestrator._handleStreamStarted({ stream: null });
+
+      expect(mockStreamingAudioPipelineService.start).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('_handleStreamStopped', () => {
+    it('should stop audio pipeline', () => {
+      orchestrator._handleStreamStopped();
+
+      expect(mockStreamingAudioPipelineService.stop).toHaveBeenCalled();
+    });
+
+    it('should clear active stream', () => {
+      const mockStream = { getAudioTracks: vi.fn(() => [{ id: 'audio-1' }]) };
+      orchestrator._handleStreamStarted({ stream: mockStream });
+
+      orchestrator._handleStreamStopped();
+
+      orchestrator._handleStreamStarted({ stream: mockStream });
+      expect(mockStreamingAudioPipelineService.start).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('_initializeAudioPipeline', () => {
+    it('should start audio warmup with stream', () => {
+      const mockStream = { getAudioTracks: vi.fn(() => [{ id: 'audio-1' }]) };
+
+      orchestrator._initializeAudioPipeline(mockStream);
+
+      expect(mockStreamingAudioPipelineService.start).toHaveBeenCalledWith(mockStream);
+    });
+
+    it('should fallback to video audio when warmup fails', async () => {
+      const mockStream = { getAudioTracks: vi.fn(() => [{ id: 'audio-1' }]) };
+      mockStreamingAudioPipelineService.start.mockResolvedValue(false);
+      mockAppState.isStreaming = true;
+      orchestrator._activeStream = mockStream;
+
+      orchestrator._initializeAudioPipeline(mockStream);
+      await vi.waitFor(() => {
+        expect(mockLogger.warn).toHaveBeenCalledWith('Audio warm-up failed - falling back to video element audio');
+      });
+
+      expect(mockStreamViewService.setMuted).toHaveBeenCalledWith(false);
+    });
+
+    it('should fallback to video audio when warmup throws', async () => {
+      const mockStream = { getAudioTracks: vi.fn(() => [{ id: 'audio-1' }]) };
+      mockStreamingAudioPipelineService.start.mockRejectedValue(new Error('Warmup error'));
+      mockAppState.isStreaming = true;
+      orchestrator._activeStream = mockStream;
+
+      orchestrator._initializeAudioPipeline(mockStream);
+      await vi.waitFor(() => {
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          'Audio warm-up error - falling back to video element audio',
+          expect.any(Error)
+        );
+      });
+
+      expect(mockStreamViewService.setMuted).toHaveBeenCalledWith(false);
+    });
+
+    it('should not fallback when stream has no audio', async () => {
+      const mockStream = { getAudioTracks: vi.fn(() => []) };
+      mockStreamingAudioPipelineService.start.mockResolvedValue(false);
+      mockAppState.isStreaming = true;
+      orchestrator._activeStream = mockStream;
+
+      orchestrator._initializeAudioPipeline(mockStream);
+      await vi.waitFor(() => {
+        expect(mockStreamingAudioPipelineService.start).toHaveBeenCalled();
+      });
+
+      expect(mockStreamViewService.setMuted).not.toHaveBeenCalled();
+    });
+
+    it('should not fallback when no longer streaming', async () => {
+      const mockStream = { getAudioTracks: vi.fn(() => [{ id: 'audio-1' }]) };
+      mockStreamingAudioPipelineService.start.mockResolvedValue(false);
+      mockAppState.isStreaming = false;
+      orchestrator._activeStream = mockStream;
+
+      orchestrator._initializeAudioPipeline(mockStream);
+      await vi.waitFor(() => {
+        expect(mockStreamingAudioPipelineService.start).toHaveBeenCalled();
+      });
+
+      expect(mockStreamViewService.setMuted).not.toHaveBeenCalled();
+    });
+
+    it('should not fallback when stream changed during warmup', async () => {
+      const mockStream1 = { getAudioTracks: vi.fn(() => [{ id: 'audio-1' }]) };
+      const mockStream2 = { getAudioTracks: vi.fn(() => [{ id: 'audio-2' }]) };
+      mockStreamingAudioPipelineService.start.mockResolvedValue(false);
+      mockAppState.isStreaming = true;
+      orchestrator._activeStream = mockStream2;
+
+      orchestrator._initializeAudioPipeline(mockStream1);
+      await vi.waitFor(() => {
+        expect(mockStreamingAudioPipelineService.start).toHaveBeenCalled();
+      });
+
+      expect(mockStreamViewService.setMuted).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('_applyVideoAudioFallback', () => {
+    it('should unmute video element', () => {
+      orchestrator._applyVideoAudioFallback();
+
+      expect(mockStreamViewService.setMuted).toHaveBeenCalledWith(false);
+      expect(mockLogger.warn).toHaveBeenCalledWith('Audio warm-up failed - falling back to video element audio');
+    });
+
+    it('should only apply fallback once', () => {
+      orchestrator._applyVideoAudioFallback();
+      orchestrator._applyVideoAudioFallback();
+
+      expect(mockStreamViewService.setMuted).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/tests/unit/features/streaming/services/streaming.orchestrator.test.js
+++ b/tests/unit/features/streaming/services/streaming.orchestrator.test.js
@@ -10,7 +10,6 @@ describe('StreamingOrchestrator', () => {
   let mockStreamingService;
   let mockAppState;
   let mockStreamingViewService;
-  let mockStreamingAudioWarmupService;
   let mockEventBus;
   let mockLogger;
   let mockStreamingRenderPipelineService;
@@ -34,12 +33,6 @@ describe('StreamingOrchestrator', () => {
       attachMutedStream: vi.fn(),
       clearStream: vi.fn(),
       setMuted: vi.fn()
-    };
-
-    mockStreamingAudioWarmupService = {
-      start: vi.fn().mockResolvedValue(true),
-      stop: vi.fn(),
-      cleanup: vi.fn()
     };
 
     mockEventBus = {
@@ -79,7 +72,6 @@ describe('StreamingOrchestrator', () => {
       streamingService: mockStreamingService,
       appState: mockAppState,
       streamViewService: mockStreamingViewService,
-      streamingAudioPipelineService: mockStreamingAudioWarmupService,
       renderPipelineService: mockStreamingRenderPipelineService,
       gpuRecordingService: mockCaptureGpuRecordingService,
       settingsService: mockSettingsService,
@@ -207,77 +199,11 @@ describe('StreamingOrchestrator', () => {
     });
   });
 
-  describe('_initializeAudioPipeline', () => {
-    it('should start audio warmup with stream', async () => {
-      const mockStream = { getAudioTracks: vi.fn(() => [{ id: 'audio-1' }]) };
-
-      orchestrator._initializeAudioPipeline(mockStream);
-
-      expect(mockStreamingAudioWarmupService.start).toHaveBeenCalledWith(mockStream);
-    });
-
-    it('should fallback to video audio when warmup fails', async () => {
-      const mockStream = { getAudioTracks: vi.fn(() => [{ id: 'audio-1' }]) };
-      mockStreamingAudioWarmupService.start.mockResolvedValue(false);
-      mockAppState.isStreaming = true;
-
-      orchestrator._initializeAudioPipeline(mockStream);
-      await vi.waitFor(() => {
-        expect(mockLogger.warn).toHaveBeenCalledWith('Audio warm-up failed - falling back to video element audio');
-      });
-
-      expect(mockStreamingViewService.setMuted).toHaveBeenCalledWith(false);
-    });
-
-    it('should fallback to video audio when warmup throws', async () => {
-      const mockStream = { getAudioTracks: vi.fn(() => [{ id: 'audio-1' }]) };
-      mockStreamingAudioWarmupService.start.mockRejectedValue(new Error('Warmup error'));
-      mockAppState.isStreaming = true;
-
-      orchestrator._initializeAudioPipeline(mockStream);
-      await vi.waitFor(() => {
-        expect(mockLogger.warn).toHaveBeenCalledWith(
-          'Audio warm-up error - falling back to video element audio',
-          expect.any(Error)
-        );
-      });
-
-      expect(mockStreamingViewService.setMuted).toHaveBeenCalledWith(false);
-    });
-
-    it('should not fallback when stream has no audio', async () => {
-      const mockStream = { getAudioTracks: vi.fn(() => []) };
-      mockStreamingAudioWarmupService.start.mockResolvedValue(false);
-      mockAppState.isStreaming = true;
-
-      orchestrator._initializeAudioPipeline(mockStream);
-      await vi.waitFor(() => {
-        expect(mockStreamingAudioWarmupService.start).toHaveBeenCalled();
-      });
-
-      expect(mockStreamingViewService.setMuted).not.toHaveBeenCalled();
-    });
-
-    it('should not fallback when no longer streaming', async () => {
-      const mockStream = { getAudioTracks: vi.fn(() => [{ id: 'audio-1' }]) };
-      mockStreamingAudioWarmupService.start.mockResolvedValue(false);
-      mockAppState.isStreaming = false;
-
-      orchestrator._initializeAudioPipeline(mockStream);
-      await vi.waitFor(() => {
-        expect(mockStreamingAudioWarmupService.start).toHaveBeenCalled();
-      });
-
-      expect(mockStreamingViewService.setMuted).not.toHaveBeenCalled();
-    });
-  });
-
   describe('_handleStreamStopped', () => {
     it('should stop render pipeline and clear video', () => {
       orchestrator._handleStreamStopped();
 
       expect(mockStreamingRenderPipelineService.stopPipeline).toHaveBeenCalled();
-      expect(mockStreamingAudioWarmupService.stop).toHaveBeenCalled();
       expect(mockStreamingViewService.clearStream).toHaveBeenCalled();
     });
 
@@ -298,7 +224,6 @@ describe('StreamingOrchestrator', () => {
       orchestrator._handleStreamError(error);
 
       expect(mockLogger.error).toHaveBeenCalledWith('Stream error:', error);
-      expect(mockStreamingAudioWarmupService.stop).toHaveBeenCalled();
       expect(mockEventBus.publish).toHaveBeenCalledWith('ui:status-message', { message: 'Error: Stream error', type: 'error' });
       expect(mockEventBus.publish).toHaveBeenCalledWith('ui:overlay-error', { message: 'Stream error' });
     });
@@ -418,7 +343,6 @@ describe('StreamingOrchestrator', () => {
       await orchestrator.onCleanup();
 
       expect(mockStreamingRenderPipelineService.cleanup).toHaveBeenCalled();
-      expect(mockStreamingAudioWarmupService.cleanup).toHaveBeenCalled();
       expect(mockStreamingService.stop).toHaveBeenCalled();
     });
   });

--- a/tests/unit/ui/app.orchestrator.test.js
+++ b/tests/unit/ui/app.orchestrator.test.js
@@ -10,6 +10,7 @@ describe('AppOrchestrator', () => {
   let orchestrator;
   let mockDeviceOrchestrator;
   let mockStreamingOrchestrator;
+  let mockStreamingAudioOrchestrator;
   let mockCaptureOrchestrator;
   let mockSettingsPreferencesOrchestrator;
   let mockSettingsDisplayModeOrchestrator;
@@ -31,6 +32,11 @@ describe('AppOrchestrator', () => {
       initialize: vi.fn().mockResolvedValue(),
       start: vi.fn(),
       stop: vi.fn(),
+      cleanup: vi.fn().mockResolvedValue()
+    };
+
+    mockStreamingAudioOrchestrator = {
+      initialize: vi.fn().mockResolvedValue(),
       cleanup: vi.fn().mockResolvedValue()
     };
 
@@ -99,6 +105,7 @@ describe('AppOrchestrator', () => {
     orchestrator = new AppOrchestrator({
       deviceOrchestrator: mockDeviceOrchestrator,
       streamingOrchestrator: mockStreamingOrchestrator,
+      streamingAudioOrchestrator: mockStreamingAudioOrchestrator,
       captureOrchestrator: mockCaptureOrchestrator,
       preferencesOrchestrator: mockSettingsPreferencesOrchestrator,
       displayModeOrchestrator: mockSettingsDisplayModeOrchestrator,
@@ -235,6 +242,7 @@ describe('AppOrchestrator', () => {
       expect(mockUpdateOrchestrator.cleanup).toHaveBeenCalled();
       expect(mockSettingsDisplayModeOrchestrator.cleanup).toHaveBeenCalled();
       expect(mockSettingsPreferencesOrchestrator.cleanup).toHaveBeenCalled();
+      expect(mockStreamingAudioOrchestrator.cleanup).toHaveBeenCalled();
       expect(mockStreamingOrchestrator.cleanup).toHaveBeenCalled();
       expect(mockCaptureOrchestrator.cleanup).toHaveBeenCalled();
       expect(mockDeviceOrchestrator.cleanup).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- Extract audio pipeline warm-up and fallback logic from `StreamingOrchestrator` to a new `StreamingAudioOrchestrator` for better separation of concerns
- Add idempotency guard to `StreamingAudioPipelineService.start()` to prevent duplicate warm-up sequences when the same stream is already active
- Wire new orchestrator through container and `AppOrchestrator` initialization flow

## Test plan
- [x] All 114 tests related to streaming/audio orchestration pass
- [x] `StreamingOrchestrator` tests updated to remove audio-related assertions
- [x] `StreamingAudioOrchestrator` has comprehensive test coverage (14 tests)
- [x] Container tests verify correct dependency wiring
- [x] `AppOrchestrator` tests verify correct initialization and cleanup order