### PR TITLE
chore(tsconfig): remove baseUrl and normalize path mappings

### DIFF
--- a/packages/prismgb-gpu/tsconfig.json
+++ b/packages/prismgb-gpu/tsconfig.json
@@ -12,9 +12,8 @@
     "declaration": true,
     "declarationDir": "dist",
     "types": ["@webgpu/types", "vite/client"],
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src/**/*"],

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,30 +1,29 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": ".",
     "outDir": "dist/typecheck",
     "paths": {
       "@/*": [
-        "src/*"
+        "./src/*"
       ],
       "@main/*": [
-        "src/main/*"
+        "./src/main/*"
       ],
       "@renderer/*": [
-        "src/renderer/*"
+        "./src/renderer/*"
       ],
       "@preload/*": [
-        "src/preload/*"
+        "./src/preload/*"
       ],
       "@shared/*": [
-        "src/shared/*"
+        "./src/shared/*"
       ],
       "@prismgb/gpu": [
-        "packages/prismgb-gpu/dist/index.d.ts"
+        "./packages/prismgb-gpu/dist/index.d.ts"
       ],
       "@prismgb/gpu/*": [
-        "packages/prismgb-gpu/dist/*"
+        "./packages/prismgb-gpu/dist/*"
       ]
     },
     "strict": true,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -18,28 +18,27 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": [
-        "src/*"
+        "./src/*"
       ],
       "@main/*": [
-        "src/main/*"
+        "./src/main/*"
       ],
       "@renderer/*": [
-        "src/renderer/*"
+        "./src/renderer/*"
       ],
       "@preload/*": [
-        "src/preload/*"
+        "./src/preload/*"
       ],
       "@shared/*": [
-        "src/shared/*"
+        "./src/shared/*"
       ],
       "@prismgb/gpu": [
-        "packages/prismgb-gpu/src"
+        "./packages/prismgb-gpu/src"
       ],
       "@prismgb/gpu/*": [
-        "packages/prismgb-gpu/src/*"
+        "./packages/prismgb-gpu/src/*"
       ]
     },
     "types": [


### PR DESCRIPTION
## Summary
- Remove `baseUrl` from `tsconfig.base.json`, `tsconfig.app.json`, and `packages/prismgb-gpu/tsconfig.json`
- Normalize all path mappings to use an explicit `./` prefix for consistency

## Test plan
- [ ] `npm run typecheck` passes
- [ ] Build succeeds across all packages
- [ ] Path alias resolution works in editor (IDE) and at build time
