### PR TITLE
chore(deps): exclude typescript major bumps from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,8 +23,27 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "vite"
         update-types: ["version-update:semver-major"]
+      # TypeScript major bumps require coordinated upgrade of @typescript-eslint/*,
+      # vitest, and re-baselining scripts/type-debt-allowlist.json. See
+      # CONTRIBUTING.md → "Upgrading TypeScript (major)".
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@typescript-eslint/eslint-plugin"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@typescript-eslint/parser"
+        update-types: ["version-update:semver-major"]
 
     groups:
+      # TypeScript ecosystem - keep TS, its lint tooling, and @types/* in sync
+      typescript-ecosystem:
+        patterns:
+          - "typescript"
+          - "@typescript-eslint/*"
+          - "@types/*"
+        update-types:
+          - "minor"
+          - "patch"
+
       # Electron ecosystem - keep together for coordinated updates
       electron-ecosystem:
         patterns:
@@ -34,7 +53,7 @@ updates:
           - "minor"
           - "patch"
 
-      # Dev dependencies (excluding electron-related)
+      # Dev dependencies (excluding electron-related and typescript-ecosystem)
       dev-dependencies:
         dependency-type: "development"
         update-types:
@@ -43,6 +62,9 @@ updates:
         exclude-patterns:
           - "electron*"
           - "vite-plugin-electron*"
+          - "typescript"
+          - "@typescript-eslint/*"
+          - "@types/*"
 
       # Production dependencies
       production-dependencies:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ Thank you for your interest in contributing to PrismGB! This document provides g
 - [Documentation](#documentation)
 - [Commit Guidelines](#commit-guidelines)
 - [Pull Request Process](#pull-request-process)
+- [Dependency Updates](#dependency-updates)
 - [Code Style](#code-style)
 - [Naming Conventions](#naming-conventions)
 - [Testing](#testing)
@@ -195,6 +196,34 @@ All PRs must pass:
 - Conventional commit validation (PR title and commits)
 
 Optional: add the `full-ci` label on a PR to run macOS and Windows validation.
+
+## Dependency Updates
+
+Routine dependency bumps are handled automatically by Dependabot (`.github/dependabot.yml`). Patch updates auto-merge; minor and major updates are labeled `needs-review`.
+
+### Packages excluded from automatic major bumps
+
+Major-version updates for these packages are **ignored** by Dependabot and must be performed manually as coordinated upgrades:
+
+- `electron`, `electron-builder`, `electron-vite`, `vite` — desktop build toolchain
+- `typescript`, `@typescript-eslint/eslint-plugin`, `@typescript-eslint/parser` — type-check toolchain
+
+### Upgrading TypeScript (major)
+
+A TypeScript major bump touches three things at once: the compiler, the lint toolchain, and the strict type-debt baseline. Do it in one branch:
+
+1. **Verify ecosystem support.** Check the peer-dependency ranges on `@typescript-eslint/eslint-plugin`, `@typescript-eslint/parser`, `vitest`, `@vitest/coverage-v8`, and `happy-dom`. If any of them does not yet support the new TS major, wait — do not partially upgrade.
+2. **Bump in lockstep.** Update `typescript` in both `package.json` and `packages/prismgb-gpu/package.json`, and bump the lint/test peers in the same commit. The two workspace `typescript` ranges must agree on a major.
+3. **Review tsconfig.** Inspect `tsconfig.base.json`, `tsconfig.app.json`, and `packages/prismgb-gpu/tsconfig.json` for `target` / `lib` / `module` values deprecated by the new release.
+4. **Re-baseline the type-debt allowlist.** Run `npm run typecheck:app:allowlist` to regenerate `scripts/type-debt-allowlist.json`. Manually review any new diagnostic codes — do not silently widen the allowlist.
+5. **Run the full local gate before pushing:**
+   ```bash
+   npm run lint
+   npm run typecheck
+   npm run build:vite
+   npm run test:coverage
+   npm run test:integration
+   ```
 
 ## Code Style
 

--- a/packages/prismgb-gpu/package.json
+++ b/packages/prismgb-gpu/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@webgpu/types": "^0.1.70",
-    "typescript": "^5.3.0",
+    "typescript": "^5.9.3",
     "vite": "^7.3.3",
     "vitest": "^4.0.0",
     "happy-dom": "^20.9.0"


### PR DESCRIPTION
PR #129 (typescript 5.9.3 -> 6.0.3) has been failing typecheck and
test CI since 2026-03-30 because @typescript-eslint v8 and vitest v4
do not yet support TypeScript 6. The same class of failure will
recur every time Dependabot proposes a TS major bump.

- Add typescript, @typescript-eslint/eslint-plugin, and
  @typescript-eslint/parser to the dependabot ignore list for
  semver-major updates, mirroring the existing electron/vite policy.
- Group typescript, @typescript-eslint/*, and @types/* into a
  typescript-ecosystem group so minor/patch bumps land coordinated.
- Tighten packages/prismgb-gpu typescript devDependency from ^5.3.0
  to ^5.9.3 so both workspace ranges agree on a major.
- Document the manual TS major upgrade flow in CONTRIBUTING.md.