### PR TITLE
[codex] clear final audit doc residue

### DIFF
--- a/CODEBASE_SIZE_REDUCTION_IMPLEMENTATION_PLAN.md
+++ b/CODEBASE_SIZE_REDUCTION_IMPLEMENTATION_PLAN.md
@@ -1681,7 +1681,7 @@ Phases and tasks:
   - Replace `tests/mocks/MockDevice.js`, factories, and settings/media fixtures where values duplicate manifest data.
 - Phase 3: Integrate with E2E fixtures.
   - Pass generated specs into `page.evaluate` helpers.
-  - Fix preload event naming drift to `onDeviceConnected`/`onDeviceDisconnected` or remove invalid direct callback simulation.
+  - Enforce current preload event names in E2E helper baseline tests.
 - Phase 4: Enforce fixture ownership.
   - Add CI drift check for device metadata in tests.
 


### PR DESCRIPTION
## Summary

Clears the last stale Phase 0-2 audit-plan residue found by the independent completion audit after #155 merged.

- Rewords the device-fixture phase plan so resolved preload event-name drift is no longer listed as future cleanup.
- Keeps the long-term enforcement target: E2E helper baselines must enforce current preload event names.

## Validation

- Targeted stale scan passes for removed DOM helper paths/imports, obsolete USB IDs, obsolete direct deviceAPI callback references, and the resolved doc phrase.
- Removed settings/IPC/transcode wrapper scan passes.
- Removed preload cleanup API scan passes.
- `node scripts/codebase-phase1-drift-report.js` passes.
- `npm run test:run -- tests/unit/codebase-reduction/non-ipc-baselines.test.js tests/unit/codebase-reduction/phase1-manifests.test.js tests/unit/preload/preload-api.invoke-contract.test.js` passes: 3 files, 29 tests.
- `git diff --check` passes.
- Commit hook reran full Vitest and passed: 154 files, 2958 tests.

## Branches

- Base: `refactor/codebase_reduction`
- Head: `refactor/codebase-size-phase-2-doc-cleanup`
- Latest commit: `7e0fe30 docs(codebase): clear final audit residue`