### PR TITLE
fix(streaming): resume render loop when window becomes visible again

### DIFF
--- a/src/renderer/infrastructure/services/streaming/streaming-render.service.ts
+++ b/src/renderer/infrastructure/services/streaming/streaming-render.service.ts
@@ -239,10 +239,17 @@ export class StreamingRenderService extends BaseService {
   }
 
   private _handleVisible(): void {
-    if (this.appState.isStreaming && this._session && this._videoElement) {
-      this._startRenderLoop(this._videoElement);
-      this.logger.debug(`${this._session.backend} rendering resumed (window visible)`);
+    if (!this.appState.isStreaming || !this._session) {
+      return;
     }
+
+    const video = this.streamViewService.getVideo();
+    if (!video) {
+      return;
+    }
+
+    this._startRenderLoop(video);
+    this.logger.debug(`${this._session.backend} rendering resumed (window visible)`);
   }
 
   private _handleHidden(): void {

--- a/tests/e2e/streaming-render-visibility.spec.js
+++ b/tests/e2e/streaming-render-visibility.spec.js
@@ -1,0 +1,72 @@
+/**
+ * Streaming Render Visibility Regression
+ *
+ * Guards the window hidden -> visible round-trip that occurs during native fullscreen
+ * space transitions on macOS (the webContents fires `visibilitychange`).
+ *
+ * Regression history: the rewritten `StreamingRenderService._handleVisible()` guarded on the
+ * cached `this._videoElement`, but `_handleHidden() -> _stopRenderLoop()` nulls that field. So
+ * after the first hide the render loop could never restart: entering/exiting fullscreen (which
+ * also resizes and clears the canvas) left a permanently black frame. The paused log fired on
+ * every hide while "rendering resumed (window visible)" never appeared once. The fix re-acquires
+ * the live video element from the view service, mirroring every other render call site.
+ *
+ * This drives the REAL path the app reacts to: a `document` `visibilitychange` event with
+ * `document.hidden` overridden. The discriminating assertion is the resume log, which is absent
+ * whenever the loop fails to restart.
+ */
+
+import { test, expect } from './fixtures/electron.fixture.js';
+
+async function setDocumentHidden(page, hidden) {
+  await page.evaluate((value) => {
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => value });
+    document.dispatchEvent(new Event('visibilitychange'));
+  }, hidden);
+}
+
+test.setTimeout(45000);
+
+test.describe('Streaming render visibility regression', () => {
+  test('resumes canvas rendering after a window hidden -> visible round-trip', async ({
+    appShell,
+    chromaticDevice,
+    streamPage,
+    page,
+  }) => {
+    const renderLogs = [];
+    page.on('console', (msg) => {
+      const text = msg.text();
+      if (/StreamingRenderService/.test(text)) {
+        renderLogs.push(text);
+      }
+    });
+
+    await appShell.waitForReady();
+    await chromaticDevice.connect();
+    await streamPage.start();
+
+    await expect
+      .poll(() => renderLogs.some((text) => /Session ready/.test(text)), {
+        timeout: 15000,
+        message: 'render session should become ready before the visibility round-trip',
+      })
+      .toBe(true);
+
+    await setDocumentHidden(page, true);
+    await expect
+      .poll(() => renderLogs.some((text) => /rendering paused \(window hidden\)/.test(text)), {
+        timeout: 10000,
+        message: 'render loop should pause when the window is hidden',
+      })
+      .toBe(true);
+
+    await setDocumentHidden(page, false);
+    await expect
+      .poll(() => renderLogs.some((text) => /rendering resumed \(window visible\)/.test(text)), {
+        timeout: 10000,
+        message: 'render loop must resume when the window becomes visible again',
+      })
+      .toBe(true);
+  });
+});

--- a/tests/unit/renderer/infrastructure/services/streaming-render.service.test.ts
+++ b/tests/unit/renderer/infrastructure/services/streaming-render.service.test.ts
@@ -139,6 +139,38 @@ describe('StreamingRenderService', () => {
     });
   });
 
+  describe('visibility pause/resume (regression: black screen after fullscreen round-trip)', () => {
+    async function startStreaming() {
+      (video as any).requestVideoFrameCallback = vi.fn();
+      (video as any).cancelVideoFrameCallback = vi.fn();
+      mockAppState.setStreaming(true);
+
+      const startPromise = service.startPipeline({
+        webgpu: true,
+        offscreenCanvas: true,
+        transferControlToOffscreen: true,
+        nativeResolution: { width: 160, height: 144 }
+      });
+      const onHealthyCallback = mockStreamHealthService.checkStreamHealth.mock.calls[0][1];
+      onHealthyCallback({});
+      await startPromise;
+    }
+
+    it('resumes the render loop when the window becomes visible after being hidden', async () => {
+      await startStreaming();
+
+      const scheduleFrame = (video as any).requestVideoFrameCallback as ReturnType<typeof vi.fn>;
+      expect(scheduleFrame).toHaveBeenCalled();
+
+      service.handlePerformanceStateChanged({ hidden: true });
+      const scheduledWhileHidden = scheduleFrame.mock.calls.length;
+
+      service.handlePerformanceStateChanged({ hidden: false });
+
+      expect(scheduleFrame.mock.calls.length).toBeGreaterThan(scheduledWhileHidden);
+    });
+  });
+
   describe('backend selection (regression: GPU capability detection wiring)', () => {
     async function startWith(streamCapabilities: Record<string, unknown>) {
       mockAppState.setStreaming(true);


### PR DESCRIPTION
## Bug

Live-device report: in performance mode, switching to fullscreen and back turned the stream **black and it never returned**.

## Root cause

The rewritten `StreamingRenderService._handleVisible()` guarded on the cached `this._videoElement`:

```js
if (this.appState.isStreaming && this._session && this._videoElement) { ... }
```

But `_handleHidden() -> _stopRenderLoop()` sets `this._videoElement = null`. So after the **first** hide, the guard can never pass again and the render loop is never restarted.

Native macOS fullscreen space transitions fire `document` `visibilitychange` (hidden → visible) **and** resize the canvas (which clears it to black). Dead render loop + cleared canvas = permanent black frame. The device log confirms it: `rendering paused (window hidden)` fired on every transition while `rendering resumed (window visible)` **never appeared once**.

`main`'s implementation re-acquired the video from `streamViewService.getVideo()` — the rewrite dropped that.

## Fix

Re-acquire the live video element from the view service in `_handleVisible()`, mirroring `_startRendering`, `_switchToGPUMidStream`, and `_switchToCanvas2DMidStream`. `_session` is untouched by hide, so restart fully restores rendering.

## Tests

- **Unit** (`streaming-render.service.test.ts`): starts a session, drives `handlePerformanceStateChanged({hidden:true})` then `({hidden:false})`, asserts the render frame is re-scheduled on visible. Verified red→green.
- **E2E** (`streaming-render-visibility.spec.js`): drives the real `visibilitychange` path against the built app and asserts the resume log. Verified it fails on the buggy build (resume log times out) and passes on the fix.

## Verification

`typecheck` ✓ · `lint` ✓ · `test:run` 163 files / 2031 tests ✓ · `dev:smoke` ✓ · e2e spec ✓