### PR TITLE
fix(notes): stop double-toggling the panel on a single button click

### DIFF
--- a/src/renderer/presentation/features/notes/notes-panel.component.ts
+++ b/src/renderer/presentation/features/notes/notes-panel.component.ts
@@ -199,7 +199,6 @@ class NotesPanelComponent extends PresentationComponent {
     const setupDisposers: Array<() => void> = [];
     this.replaceManaged(NOTES_PANEL_SETUP_LIFECYCLE, () => setupDisposers.splice(0).reverse().forEach((dispose) => dispose()));
     this._setupNewButton(setupDisposers);
-    this._setupToggleButton(setupDisposers);
     this._setupEscapeKey(setupDisposers);
     this.layout!.initialize({
       panelElement: this.elements.notesPanel,
@@ -338,11 +337,6 @@ class NotesPanelComponent extends PresentationComponent {
   _setupNewButton(setupDisposers: Array<() => void>): void {
     if (!this.elements?.notesNewBtn) return;
     setupDisposers.push(this.listen(this.elements.notesNewBtn, 'click', () => this._createNewNote()));
-  }
-
-  _setupToggleButton(setupDisposers: Array<() => void>): void {
-    if (!this.elements?.notesBtn) return;
-    setupDisposers.push(this.listen(this.elements.notesBtn, 'click', () => this.toggle()));
   }
 
   _createNewNote(): void {

--- a/tests/e2e/notes-panel.spec.js
+++ b/tests/e2e/notes-panel.spec.js
@@ -1,0 +1,72 @@
+/**
+ * Notes Panel Toggle Regression
+ *
+ * Guards that a single click on the toolbar notes button opens the panel and a second click
+ * closes it.
+ *
+ * Regression history: the notes button was double-wired. The refactor migrated notes onto the
+ * declarative `data-action="notes.toggle"` dispatcher (like the settings and shader buttons),
+ * but the component kept its `main`-era imperative `_setupToggleButton()` click listener. A
+ * single click therefore invoked `toggle()` twice — the panel opened then immediately closed,
+ * so "nothing showed up" and the log emitted a paired shown/hidden per click. The fix removes
+ * the component self-wire and relies solely on the dispatcher.
+ *
+ * The existing component unit specs asserted the (now-removed) self-wire and never saw the
+ * cross-layer duplication, which is why only an e2e catches this.
+ */
+
+import { test, expect } from './fixtures/electron.fixture.js';
+
+function readPanelState(page) {
+  return page.evaluate(() => {
+    const el = document.getElementById('notesPanel');
+    if (!el) return { exists: false };
+    const cs = getComputedStyle(el);
+    const r = el.getBoundingClientRect();
+    return {
+      exists: true,
+      hasVisibleClass: el.classList.contains('visible'),
+      opacity: cs.opacity,
+      onScreen: r.width > 0 && r.right > 0 && r.x < window.innerWidth && r.bottom > 0 && r.y < window.innerHeight,
+    };
+  });
+}
+
+function clickNotesButton(page) {
+  return page.evaluate(() => document.getElementById('notesBtn')?.click());
+}
+
+test.setTimeout(45000);
+
+test.describe('Notes panel toggle regression', () => {
+  test('opens on the first notes-button click and closes on the second', async ({
+    appShell,
+    chromaticDevice,
+    streamPage,
+    page,
+  }) => {
+    await appShell.waitForReady();
+    await chromaticDevice.connect();
+    await streamPage.start();
+
+    const initial = await readPanelState(page);
+    expect(initial.exists).toBe(true);
+    expect(initial.hasVisibleClass).toBe(false);
+
+    await clickNotesButton(page);
+    await expect
+      .poll(async () => {
+        const state = await readPanelState(page);
+        return state.hasVisibleClass && state.opacity === '1' && state.onScreen;
+      }, { timeout: 4000, message: 'a single click must open and keep the notes panel visible' })
+      .toBe(true);
+
+    await clickNotesButton(page);
+    await expect
+      .poll(async () => {
+        const state = await readPanelState(page);
+        return !state.hasVisibleClass && state.opacity === '0';
+      }, { timeout: 4000, message: 'a second click must close the notes panel' })
+      .toBe(true);
+  });
+});

--- a/tests/unit/renderer/presentation/features/notes/notes-panel.component.test.ts
+++ b/tests/unit/renderer/presentation/features/notes/notes-panel.component.test.ts
@@ -62,12 +62,11 @@ describe('NotesPanelComponent', () => {
       component.initialize(mockElements);
       expect(mockLogger.debug).toHaveBeenCalledWith('NotesPanelComponent initialized');
     });
-    it('should reinitialize without stacking panel toggle listeners', () => {
-      component.initialize(mockElements);
+    it('should not self-wire the notes button (toggling is the action dispatcher\'s responsibility)', () => {
       component.initialize(mockElements);
       mockElements.notesBtn.click();
-      expect(component.isVisible).toBe(true);
-      expect(mockElements.notesPanel.classList.contains(CSSClasses.VISIBLE)).toBe(true);
+      expect(component.isVisible).toBe(false);
+      expect(mockElements.notesPanel.classList.contains(CSSClasses.VISIBLE)).toBe(false);
     });
     it('should clear stale panel state when reinitialized without panel elements', () => {
       component.initialize(mockElements);
@@ -496,12 +495,6 @@ describe('NotesPanelComponent', () => {
   describe('Button click workflows', () => {
     beforeEach(() => {
       component.initialize(mockElements);
-    });
-    it('should toggle panel visibility on notes button click', () => {
-      mockElements.notesBtn.click();
-      expect(component.isVisible).toBe(true);
-      mockElements.notesBtn.click();
-      expect(component.isVisible).toBe(false);
     });
     it('should create new note on new button click', () => {
       mockNotesService.createNote.mockReturnValue({ id: 'new_note', title: 'Untitled Note' });


### PR DESCRIPTION
## Bug

Live-device report: the notes panel "is not working on click, nothing is showing up." The log showed a **paired** `Notes panel shown` → `Notes panel hidden` for every click.

## Root cause

The notes button was **double-wired**. The refactor migrated notes onto the declarative dispatcher — `data-action="notes.toggle"` → `UIActionBindings` → `toggleNotesPanel()` → `component.toggle()`, exactly like the settings and shader buttons. But the component kept its `main`-era imperative wiring:

```js
_setupToggleButton(setupDisposers) {
  setupDisposers.push(this.listen(this.elements.notesBtn, 'click', () => this.toggle()));
}
```

A single click fired `toggle()` **twice** (dispatcher + self-wire) → open then immediately close → nothing visible, paired `shown`/`hidden` per click.

Settings and shader do **not** self-wire — they route solely through the dispatcher. Notes' `_setupToggleButton` is the un-deleted vestige.

## Fix

Remove `_setupToggleButton` (method + call); rely on the `notes.toggle` dispatcher. `_setupEscapeKey` and the event subscriptions are untouched — Escape-to-close still works (and is why the notes dispatcher entry correctly omits `stopPropagation`: notes has no click-outside listener).

## Tests

- **E2E** (`notes-panel.spec.js`): clicks the notes button once and asserts the panel actually becomes visible (`.visible`, opacity 1, on-screen), then closes on a second click. This is the layer that sees the cross-layer duplication — the answer to "Playwright should have caught this." Verified **red** on the buggy build (panel never opens), **green** after the fix.
- **Unit**: repurposed the reinitialize spec to guard that the component no longer self-wires the button; dropped the now-redundant button-click toggle spec (covered by the `toggle()` block + e2e).

## Verification

`typecheck` ✓ · `lint` ✓ · `test:run` 163 files / 2030 tests ✓ · `dev:smoke` ✓ · notes e2e red→green ✓