### PR TITLE
ci: run CI on Node 24 to match the npm 11 lockfile

### DIFF
--- a/.github/actions/setup-node-deps/action.yml
+++ b/.github/actions/setup-node-deps/action.yml
@@ -5,7 +5,7 @@ inputs:
   node-version:
     description: Node.js version to use
     required: false
-    default: '22'
+    default: '24'
   skip-native-deps:
     description: Skip native dependency installation
     required: false

--- a/.github/workflows/build-smoke.yml
+++ b/.github/workflows/build-smoke.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22'
+          node-version: '24'
 
       - name: Generate build matrix
         id: matrix


### PR DESCRIPTION
## Problem

CI on the `refactor/codebase_reduction` → `main` PR (#150) fails at **dependency install**, before any lint/test/build runs:

```
npm error `npm ci` can only install packages when your package.json and package-lock.json are in sync.
npm error Missing: conventional-commits-parser@6.4.0 from lock file
```

## Root cause

npm major-version skew, **not** a code or lockfile-content problem:

- `package-lock.json` is generated with **npm 11** (Node 24/25 — local dev).
- `.github/actions/setup-node-deps` defaulted to **Node 22**, which ships **npm 10**.
- npm 10 rejects npm 11's handling of the `conventional-commits-parser` *optional peer dependency*, so `npm ci` errors out and gates every job.

Reproduced locally: `npx npm@10 ci` fails with the exact error; `npm ci` on npm 11 passes (`exit 0`). Pre-existing — the branch was already red before the two recent bug-fix merges, neither of which touched `package.json`/`package-lock.json`.

## Fix

Align CI to the npm major the lockfile is built with: bump the `setup-node-deps` default and the `build-smoke` workflow from Node 22 → 24. `engines` is `>=22.12`, so 24 is in range, and this keeps CI in step with local dev (npm 11) so routine `npm install`s don't re-break CI.

## Verification

`npm ci --dry-run` on npm 11 (Node 24 parity) → exit 0. Once merged, PR #150's CI re-runs on Node 24 and should get past install into the actual lint/test/build jobs.