### PR TITLE
ci: scope node_modules cache by native-deps mode to stop electron poisoning

### DIFF
--- a/.github/actions/setup-node-deps/action.yml
+++ b/.github/actions/setup-node-deps/action.yml
@@ -38,7 +38,7 @@ runs:
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: node_modules
-        key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ inputs.node-version }}-${{ hashFiles('package-lock.json') }}
+        key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ inputs.node-version }}-native-${{ inputs.skip-native-deps }}-${{ hashFiles('package-lock.json') }}
 
     - name: Install Linux dependencies
       if: runner.os == 'Linux' && inputs.skip-native-deps != 'true'


### PR DESCRIPTION
## Problem

On PR #150, `Tests / Test (ubuntu-latest)` fails at `npm run test:run` — two main-process suites (`container.test.ts`, `container.shutdown.test.ts`) error with `Electron failed to install correctly` / `Named export 'ipcRenderer' not found`. `Tests / Test (ubuntu-24.04-arm)` passes the same command. Locally `test:run` is fully green.

## Root cause

The `node_modules` cache key omits the `skip-native-deps` dimension:

```
node-modules-${os}-${arch}-${node-version}-${hash(package-lock)}
```

- `PR Lint` and `Build Smoke` call the setup action with `skip-native-deps: 'true'` → `npm ci --ignore-scripts` → **no electron binary downloaded** → they save `node_modules` under that key.
- `Tests (ubuntu-latest)` needs the full install, but restores the **same key** — the run log shows `Cache hit for: node-modules-Linux-X64-24-…`, so its own `npm ci` step is skipped (gated on `cache-hit != 'true'`). It runs against an electron-less `node_modules` → the container suites fail.
- `Tests (ubuntu-24.04-arm)` has no ignore-scripts jobs on ARM64, so its cache is only ever populated by a full install → electron present → passes.

(The Node 22→24 bump didn't create this; it minted a fresh cache under the new key, and an ignore-scripts job won the race to populate it, exposing the latent collision.)

## Fix

Add `skip-native-deps` to the cache key so the two install modes never share a cache:

```
node-modules-${os}-${arch}-${node-version}-native-${skip-native-deps}-${hash(package-lock)}
```

The Tests job now gets its own `native-false` cache and always performs a full `npm ci` (electron installed); lint/build-smoke keep their `native-true` cache. Everything before `test:run` (lint, dead-code, typecheck, build) already passed in CI, so this is the last gate.