### PR TITLE
fix(streaming): emit canvas expiry on pipeline stop so stream restarts get a fresh canvas

### DIFF
--- a/src/renderer/infrastructure/services/streaming/streaming-render.service.ts
+++ b/src/renderer/infrastructure/services/streaming/streaming-render.service.ts
@@ -193,7 +193,7 @@ export class StreamingRenderService extends BaseService {
         });
       }
 
-      this._session.terminate();
+      this._session.terminate({ emitCanvasExpired: true });
       this._session = null;
 
       if (isGpu) {
@@ -273,7 +273,7 @@ export class StreamingRenderService extends BaseService {
 
     if (this._session && this._session.backend === 'webgpu') {
       this.logger.info('Performance mode enabled - terminating GPU worker for Canvas2D on next stream');
-      this._session.terminate();
+      this._session.terminate({ emitCanvasExpired: true });
       this._session = null;
     }
   }
@@ -538,7 +538,7 @@ export class StreamingRenderService extends BaseService {
   async resetCanvasState(): Promise<void> {
     this._stopRenderLoop();
     if (this._session) {
-      this._session.terminate();
+      this._session.terminate({ emitCanvasExpired: false });
       this._session = null;
     }
   }

--- a/tests/e2e/stream-restart-regression.spec.js
+++ b/tests/e2e/stream-restart-regression.spec.js
@@ -1,0 +1,75 @@
+/**
+ * Regression: restarting a stream after a stop must produce a working render
+ * pipeline. Terminating a WebGPU session leaves the canvas permanently
+ * transferred, so the stop path must trigger canvas recreation — otherwise
+ * every subsequent start fails with "Cannot transfer control from a canvas
+ * for more than one time" and the stream immediately self-stops.
+ */
+
+import { test, expect } from './fixtures/electron.fixture.js';
+
+test.setTimeout(45000);
+
+const RENDER_PIPELINE_ERROR_PATTERNS = [
+  'Cannot transfer control from a canvas',
+  'Failed to initialize worker renderer',
+  'Failed to initialize session',
+];
+
+function collectRenderPipelineErrors(page) {
+  const errors = [];
+  page.on('console', (message) => {
+    if (message.type() !== 'error') return;
+    const text = message.text();
+    if (RENDER_PIPELINE_ERROR_PATTERNS.some((pattern) => text.includes(pattern))) {
+      errors.push(text);
+    }
+  });
+  return errors;
+}
+
+test.describe('Stream Restart with Chromatic Media Environment', () => {
+  test('restarts streaming after stop with a working render pipeline', async ({
+    appShell,
+    chromaticDevice,
+    streamPage,
+  }) => {
+    const pipelineErrors = collectRenderPipelineErrors(streamPage.page);
+
+    await appShell.waitForReady();
+    await streamPage.suppressDownloads();
+    await chromaticDevice.connect();
+
+    await streamPage.start();
+    await streamPage.stop();
+
+    await streamPage.start();
+    await streamPage.page.waitForTimeout(2000);
+    await streamPage.expectStreaming({ timeout: 1000 });
+    await streamPage.captureScreenshot();
+
+    await streamPage.stop();
+
+    expect(pipelineErrors).toEqual([]);
+  });
+
+  test('survives repeated stop/start cycles', async ({
+    appShell,
+    chromaticDevice,
+    streamPage,
+  }) => {
+    const pipelineErrors = collectRenderPipelineErrors(streamPage.page);
+
+    await appShell.waitForReady();
+    await chromaticDevice.connect();
+
+    for (let cycle = 0; cycle < 3; cycle++) {
+      await streamPage.start();
+      await streamPage.page.waitForTimeout(1500);
+      await streamPage.expectStreaming({ timeout: 1000 });
+      await streamPage.stop();
+    }
+
+    expect(pipelineErrors).toEqual([]);
+  });
+});

--- a/tests/unit/platform/gpu/application/video-session.test.ts
+++ b/tests/unit/platform/gpu/application/video-session.test.ts
@@ -99,6 +99,40 @@ describe('GpuVideoRendererSession', () => {
     session.terminate();
   });
 
+  it('invokes onCanvasExpired only when terminate requests it', async () => {
+    const canvas = createMockCanvas() as unknown as HTMLCanvasElement;
+    const worker = createWorkerMock();
+    const onCanvasExpired = vi.fn();
+
+    const sessionPromise = createGpuVideoRendererSession({
+      canvas,
+      nativeResolution: { width: 160, height: 144 },
+      preferredBackend: 'webgpu',
+      createWorker: () => worker,
+      onCanvasExpired,
+      capabilities: createRenderCapabilitiesFixture({
+        webgpu: true,
+        offscreenCanvas: true,
+        transferControlToOffscreen: true,
+        preferredBackend: 'webgpu'
+      })
+    });
+
+    setTimeout(() => {
+      worker.onmessage?.({
+        data: createWorkerResponse(WorkerResponseType.READY, { backend: 'webgpu' })
+      } as MessageEvent);
+    }, 10);
+
+    const session = await sessionPromise;
+
+    session.terminate();
+    expect(onCanvasExpired).not.toHaveBeenCalled();
+
+    session.terminate({ emitCanvasExpired: true });
+    expect(onCanvasExpired).toHaveBeenCalledTimes(1);
+  });
+
   it('reports scaled target dimensions (not a hardcoded native width)', async () => {
     const canvas = createMockCanvas() as unknown as HTMLCanvasElement;
     const worker = createWorkerMock();

--- a/tests/unit/renderer/application/orchestrators/streaming.orchestrator.test.ts
+++ b/tests/unit/renderer/application/orchestrators/streaming.orchestrator.test.ts
@@ -78,6 +78,18 @@ describe('StreamingOrchestrator', () => {
       expect(mockEventBus.subscribe).toHaveBeenCalledWith('stream:started', expect.any(Function));
       expect(mockEventBus.subscribe).toHaveBeenCalledWith('stream:stopped', expect.any(Function));
       expect(mockEventBus.subscribe).toHaveBeenCalledWith('stream:error', expect.any(Function));
+    });
+
+    it('routes canvas expiry to the streaming render service', async () => {
+      await orchestrator.initialize();
+
+      const canvasExpiredSubscription = mockEventBus.subscribe.mock.calls
+        .find(([channel]) => channel === 'render:canvas-expired');
+      expect(canvasExpiredSubscription).toBeDefined();
+
+      await canvasExpiredSubscription[1]();
+
+      expect(mockStreamingRenderService.handleCanvasExpired).toHaveBeenCalledTimes(1);
       expect(mockEventBus.subscribe).toHaveBeenCalledWith('performance:render-mode-changed', expect.any(Function));
       expect(mockEventBus.subscribe).toHaveBeenCalledWith('performance:state-changed', expect.any(Function));
       expect(mockEventBus.subscribe).toHaveBeenCalledWith('device:disconnected-during-session', expect.any(Function));

--- a/tests/unit/renderer/infrastructure/services/streaming-render.service.test.ts
+++ b/tests/unit/renderer/infrastructure/services/streaming-render.service.test.ts
@@ -137,6 +137,47 @@ describe('StreamingRenderService', () => {
 
       expect(mockSession.terminate).toHaveBeenCalled();
     });
+
+    it('requests canvas expiry on stop so a restarted stream gets a fresh canvas', async () => {
+      mockAppState.setStreaming(true);
+
+      const startPromise = service.startPipeline({
+        webgpu: true,
+        offscreenCanvas: true,
+        transferControlToOffscreen: true,
+        nativeResolution: { width: 160, height: 144 }
+      });
+
+      const onHealthyCallback = mockStreamHealthService.checkStreamHealth.mock.calls[0][1];
+      onHealthyCallback({});
+      await startPromise;
+
+      service.stopPipeline();
+
+      expect(mockSession.terminate).toHaveBeenCalledWith({ emitCanvasExpired: true });
+    });
+  });
+
+  describe('performance mode with idle GPU session', () => {
+    it('requests canvas expiry when terminating the idle GPU session', async () => {
+      mockAppState.setStreaming(true);
+
+      const startPromise = service.startPipeline({
+        webgpu: true,
+        offscreenCanvas: true,
+        transferControlToOffscreen: true,
+        nativeResolution: { width: 160, height: 144 }
+      });
+
+      const onHealthyCallback = mockStreamHealthService.checkStreamHealth.mock.calls[0][1];
+      onHealthyCallback({});
+      await startPromise;
+
+      mockAppState.setStreaming(false);
+      await service.handlePerformanceModeChanged(true);
+
+      expect(mockSession.terminate).toHaveBeenCalledWith({ emitCanvasExpired: true });
+    });
   });
 
   describe('visibility pause/resume (regression: black screen after fullscreen round-trip)', () => {


### PR DESCRIPTION
## Summary

Restarting a stream after a stop was permanently broken on the WebGPU backend: the first stream worked, and every subsequent start failed with `Cannot transfer control from a canvas for more than one time`, after which the orchestrator immediately self-stopped the otherwise-healthy stream.

## Root cause

`transferControlToOffscreen()` is a once-per-canvas-lifetime operation. The designed recovery is the canvas-expiry chain: `session.terminate({ emitCanvasExpired: true })` → `RENDER.CANVAS_EXPIRED` → `StreamingOrchestrator` → `canvasLifecycleService.handleCanvasExpired()` → fresh canvas element. But `DefaultGpuVideoRendererSession.terminate()` treats `emitCanvasExpired` as opt-in, and the two stop paths that end a GPU session outside a manual-recreate flow called it bare:

- `StreamingRenderService.stopPipeline()` (every user-initiated stream stop)
- `StreamingRenderService._handlePerformanceModeEnabled()` (idle GPU session terminated for Canvas2D)

So the expiry never fired, the consumed canvas survived, and the next `_startRendering` handed it to a new `WorkerRendererClient`.

## Fix

Both stop paths now pass `{ emitCanvasExpired: true }`; `resetCanvasState()` — which is invoked from *inside* the recreate flow — passes an explicit `{ emitCanvasExpired: false }` so the recursion hazard is pinned in code. Six changed lines in `streaming-render.service.ts`.

## Regression coverage

- **Unit (RED→GREEN):** `stopPipeline` and the performance-mode path assert the expiry option on `terminate` (both failed before the fix).
- **Chain-link units (new):** `video-session` pins the emit contract (`terminate()` silent, `terminate({emitCanvasExpired: true})` fires the callback); `streaming.orchestrator` pins the `render:canvas-expired` → `handleCanvasExpired` wiring.
- **E2E (new spec `stream-restart-regression.spec.js`):** stop→restart with a screenshot through the restarted pipeline, a 3× stop/start cycle, and a console tripwire for the transfer/init error signatures. Note: the e2e harness launches electron with `--disable-gpu` (Canvas2D backend), so the WebGPU transfer path itself is guarded deterministically by the unit chain; the e2e spec guards the behavioral restart contract and arms the tripwire on GPU-enabled machines.

## Verification

`lint`, `lint:dead-code`, `typecheck`, `test:run` (163 files / 2,034 tests — baseline +4), `dev:smoke` all exit 0; the new e2e spec passes 2/2.
