### PR TITLE
test(e2e): fix Electron launch-death and screenshot-timeout flakes

### DIFF
--- a/tests/e2e/fixtures/electron.fixture.js
+++ b/tests/e2e/fixtures/electron.fixture.js
@@ -34,7 +34,13 @@ function createTestUserDataDir() {
 export const test = base.extend({
   /**
    * Electron app instance fixture
-   * Launches the built app with test-mode flags
+   * Launches the built app with test-mode flags.
+   *
+   * Readiness is gated on `app.firstWindow()`, never `app.evaluate(() => app.whenReady())`.
+   * The main window is created inside the `app.whenReady().then(...)` boot chain, so a
+   * resolved `firstWindow()` already implies `whenReady()` completed — and it does so
+   * without a main-process `evaluate` round-trip, which races the first window's initial
+   * navigation and intermittently throws "Execution context was destroyed".
    */
   electronApp: async ({}, use) => {
     const userDataDir = createTestUserDataDir();
@@ -71,9 +77,7 @@ export const test = base.extend({
     });
 
     // Wait for app to be ready
-    await app.evaluate(async ({ app: electronApp }) => {
-      await electronApp.whenReady();
-    });
+    await app.firstWindow();
 
     // Provide the app to the test
     await use(app);

--- a/tests/e2e/pages/stream.page.js
+++ b/tests/e2e/pages/stream.page.js
@@ -170,9 +170,18 @@ export class StreamPage {
     await this.#clickControl(this.shaderButton);
   }
 
+  /**
+   * Triggers a screenshot and waits for the "Screenshot saved" status.
+   *
+   * The e2e app runs `--disable-gpu`, so frame capture + full-resolution PNG
+   * `toBlob` encoding is CPU-bound (~1s baseline, heavy tail under load). The
+   * capture always completes and a genuine failure surfaces as an "Error taking
+   * screenshot" status, so the wait is given generous headroom rather than a
+   * tight cap that flakes when the encode is starved on a contended runner.
+   */
   async captureScreenshot() {
     await this.#clickControl(this.screenshotButton);
-    await expect(this.statusMessage).toContainText('Screenshot saved', { timeout: 5000 });
+    await expect(this.statusMessage).toContainText('Screenshot saved', { timeout: 15000 });
   }
 
   async startRecording() {


### PR DESCRIPTION
## Summary

Fixes the two root-caused e2e flakes from `npm run test:e2e` (baseline: **13 failed / 78 passed**, 91 tests). Both changes are **test-only — zero `src/` changes.**

## Flake 1 — Electron launch-death race (12 of 13 failures)

Every failure threw the same error at `electron.fixture.js`, in ~260–277ms:

```
electronApplication.evaluate: Execution context was destroyed, most likely because of a navigation.
```

…from the readiness gate `await app.evaluate(() => app.whenReady())`. A standalone harness mirroring the fixture lifecycle (launch → readiness gate → close → immediate relaunch) captured the app's own stdout + process exit and proved the process was **alive and healthy** on every failure (`exitInfo: null`, `processAliveAtThrow: true`, boot reached `WindowService › Loading built files`). It is a **Playwright CDP race** — `app.evaluate()` reaches into the main process at the exact moment the first `BrowserWindow` is created and navigates (`loadFile`) — **not** a crash, and **not** a single-instance-lock collision (per-test `userDataDir` isolates the lock).

The `whenReady()` evaluate is also redundant: the window is created *inside* `app.whenReady().then(() => application.initialize())`, so `app.firstWindow()` is a navigation-safe, stronger readiness signal.

**Fix:** gate on `app.firstWindow()`; JSDoc added so it isn't reverted to `whenReady()`.

**Verified:** harness **5/60 → 0/60**; suite failures **13 → 1**.

## Flake 2 — screenshot status timeout too tight (1 of 13)

`streaming-smoke` failed `toContainText('Screenshot saved', {timeout: 5000})` with no error logged. A console-capturing diagnostic (30 runs, quiet + under CPU load) showed the capture **always completes in ~1.3s and never hangs** — under `--disable-gpu`, frame capture + full-res PNG `toBlob` is CPU-bound with a heavy tail that occasionally exceeds 5s under contention.

**Fix:** raise the status wait to 15s (a genuine failure still throws → surfaces as "Error taking screenshot"; the `.png` download is asserted independently later in the same test).

## Verification

- Standalone launch harness: `whenReady` 5/60 fail → `firstWindow` 0/60 fail.
- Full suite after fix: launch-death class eliminated (0 occurrences across 2 post-fix runs); screenshot passes.
- Pre-push gates green: typecheck + lint + `test:run` (162 files / 2030 tests).

## Out of scope (follow-up)

A third, unrelated flake surfaced separately: `fullscreen-exit-regression` (`#fsExitBtn` auto-hide reveal race). That test is `skipInCI` by default, so it does not affect CI; it will be addressed in a follow-up after this merges.
